### PR TITLE
Add options for controlling the wire and node style

### DIFF
--- a/examples/bevy_demo.rs
+++ b/examples/bevy_demo.rs
@@ -49,7 +49,7 @@ fn initialize(mut commands: Commands, mut egui: ResMut<EguiContext>) {
     commands.insert_resource(State {
         graph,
         view,
-        node_color: color,
+        socket_color: color,
         wire_color: color,
         ..State::default()
     });
@@ -90,14 +90,14 @@ fn update(mut egui_context: ResMut<EguiContext>, mut state: ResMut<State>) {
                         ui.add(egui::Slider::new(&mut state.wire_width, 0.5..=10.0));
                     });
                     ui.horizontal(|ui| {
-                        ui.label("Node radius:");
-                        ui.add(egui::Slider::new(&mut state.node_radius, 1.0..=10.0));
+                        ui.label("Socket radius:");
+                        ui.add(egui::Slider::new(&mut state.socket_radius, 1.0..=10.0));
                     });
                     ui.horizontal(|ui| {
                         ui.label("Wire color:");
                         ui.color_edit_button_srgba(&mut state.wire_color);
-                        ui.label("Node color:");
-                        ui.color_edit_button_srgba(&mut state.node_color);
+                        ui.label("Socket color:");
+                        ui.color_edit_button_srgba(&mut state.socket_color);
                     });
                 });
         });
@@ -109,8 +109,8 @@ struct State {
     view: egui_graph::View,
     interaction: Interaction,
     flow: egui::Direction,
-    node_radius: f32,
-    node_color: egui::Color32,
+    socket_radius: f32,
+    socket_color: egui::Color32,
     wire_width: f32,
     wire_color: egui::Color32,
 }
@@ -159,8 +159,8 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             .inputs(inputs)
             .outputs(outputs)
             .flow(state.flow)
-            .node_radius(state.node_radius)
-            .node_color(state.node_color)
+            .socket_radius(state.socket_radius)
+            .socket_color(state.socket_color)
             .show(graph_view, nctx, ui, |ui| match node.kind {
                 NodeKind::Label => {
                     ui.label(&node.name);
@@ -294,8 +294,8 @@ impl Default for State {
             graph: Default::default(),
             view: Default::default(),
             interaction: Default::default(),
-            node_color: Default::default(),
-            node_radius: 3.0,
+            socket_color: Default::default(),
+            socket_radius: 3.0,
             wire_width: 1.0,
             wire_color: Default::default(),
             flow: egui::Direction::LeftToRight,

--- a/examples/bevy_demo.rs
+++ b/examples/bevy_demo.rs
@@ -49,12 +49,9 @@ fn initialize(mut commands: Commands, mut egui: ResMut<EguiContext>) {
     commands.insert_resource(State {
         graph,
         view,
-        interaction: Default::default(),
-        flow: egui::Direction::LeftToRight,
-        node_radius: 3.0,
         node_color: color,
         wire_color: color,
-        wire_width: 1.0,
+        ..State::default()
     });
 }
 
@@ -249,7 +246,6 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let bezier = egui_graph::bezier::Cubic::from_edge_points(a_out, b_in);
         let dist_per_pt = 5.0;
         let pts: Vec<_> = bezier.flatten(dist_per_pt).collect();
-        let color = ui.visuals().weak_text_color().linear_multiply(0.5);
         let stroke = egui::Stroke {
             width: state.wire_width,
             color: state.wire_color,

--- a/examples/bevy_demo.rs
+++ b/examples/bevy_demo.rs
@@ -45,13 +45,16 @@ fn initialize(mut commands: Commands, mut egui: ResMut<EguiContext>) {
     view.layout.insert(egui::Id::new(d), [50.0, 0.0].into());
     view.layout.insert(egui::Id::new(e), [200.0, 0.0].into());
 
+    let color = egui::Color32::from_gray(140);
     commands.insert_resource(State {
         graph,
         view,
         interaction: Default::default(),
         flow: egui::Direction::LeftToRight,
         node_radius: 3.0,
-        node_color: egui::Color32::from_gray(140),
+        node_color: color,
+        wire_color: color,
+        wire_width: 1.0,
     });
 }
 
@@ -86,10 +89,16 @@ fn update(mut egui_context: ResMut<EguiContext>, mut state: ResMut<State>) {
                         ui.radio_value(&mut state.flow, egui::Direction::BottomUp, "Up");
                     });
                     ui.horizontal(|ui| {
-                        ui.label("Node radius:");
-                        ui.add(egui::Slider::new(&mut state.node_radius, 0.0..=10.0));
+                        ui.label("Wire width:");
+                        ui.add(egui::Slider::new(&mut state.wire_width, 0.5..=10.0));
                     });
                     ui.horizontal(|ui| {
+                        ui.label("Node radius:");
+                        ui.add(egui::Slider::new(&mut state.node_radius, 1.0..=10.0));
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Wire color:");
+                        ui.color_edit_button_srgba(&mut state.wire_color);
                         ui.label("Node color:");
                         ui.color_edit_button_srgba(&mut state.node_color);
                     });
@@ -105,6 +114,8 @@ struct State {
     flow: egui::Direction,
     node_radius: f32,
     node_color: egui::Color32,
+    wire_width: f32,
+    wire_color: egui::Color32,
 }
 
 #[derive(Default)]
@@ -239,8 +250,10 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let dist_per_pt = 5.0;
         let pts: Vec<_> = bezier.flatten(dist_per_pt).collect();
         let color = ui.visuals().weak_text_color().linear_multiply(0.5);
-        let width = 1.0;
-        let stroke = egui::Stroke { width, color };
+        let stroke = egui::Stroke {
+            width: state.wire_width,
+            color: state.wire_color,
+        };
         ui.painter().add(egui::Shape::line(pts.clone(), stroke));
     }
 
@@ -290,6 +303,8 @@ impl Default for State {
             interaction: Default::default(),
             node_color: Default::default(),
             node_radius: 3.0,
+            wire_width: 1.0,
+            wire_color: Default::default(),
             flow: egui::Direction::LeftToRight,
         }
     }

--- a/examples/bevy_demo.rs
+++ b/examples/bevy_demo.rs
@@ -236,6 +236,10 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
 fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) {
     // Draw the attached edges.
     let indices: Vec<_> = state.graph.edge_indices().collect();
+    let stroke = egui::Stroke {
+        width: state.wire_width,
+        color: state.wire_color,
+    };
     for e in indices {
         let (na, nb) = state.graph.edge_endpoints(e).unwrap();
         let (output, input) = *state.graph.edge_weight(e).unwrap();
@@ -246,10 +250,6 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let bezier = egui_graph::bezier::Cubic::from_edge_points(a_out, b_in);
         let dist_per_pt = 5.0;
         let pts: Vec<_> = bezier.flatten(dist_per_pt).collect();
-        let stroke = egui::Stroke {
-            width: state.wire_width,
-            color: state.wire_color,
-        };
         ui.painter().add(egui::Shape::line(pts.clone(), stroke));
     }
 
@@ -258,9 +258,6 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let bezier = edge.bezier_cubic();
         let dist_per_pt = 5.0;
         let pts = bezier.flatten(dist_per_pt).collect();
-        let color = ui.visuals().weak_text_color().linear_multiply(0.5);
-        let width = 1.0;
-        let stroke = egui::Stroke { width, color };
         ui.painter().add(egui::Shape::line(pts, stroke));
     }
 }

--- a/examples/bevy_demo.rs
+++ b/examples/bevy_demo.rs
@@ -50,6 +50,8 @@ fn initialize(mut commands: Commands, mut egui: ResMut<EguiContext>) {
         view,
         interaction: Default::default(),
         flow: egui::Direction::LeftToRight,
+        node_radius: 3.0,
+        node_color: egui::Color32::from_gray(140),
     });
 }
 
@@ -83,6 +85,14 @@ fn update(mut egui_context: ResMut<EguiContext>, mut state: ResMut<State>) {
                         ui.radio_value(&mut state.flow, egui::Direction::RightToLeft, "Left");
                         ui.radio_value(&mut state.flow, egui::Direction::BottomUp, "Up");
                     });
+                    ui.horizontal(|ui| {
+                        ui.label("Node radius:");
+                        ui.add(egui::Slider::new(&mut state.node_radius, 0.0..=10.0));
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Node color:");
+                        ui.color_edit_button_srgba(&mut state.node_color);
+                    });
                 });
         });
 }
@@ -93,6 +103,8 @@ struct State {
     view: egui_graph::View,
     interaction: Interaction,
     flow: egui::Direction,
+    node_radius: f32,
+    node_color: egui::Color32,
 }
 
 #[derive(Default)]
@@ -139,6 +151,8 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             .inputs(inputs)
             .outputs(outputs)
             .flow(state.flow)
+            .node_radius(state.node_radius)
+            .node_color(state.node_color)
             .show(graph_view, nctx, ui, |ui| match node.kind {
                 NodeKind::Label => {
                     ui.label(&node.name);
@@ -274,6 +288,8 @@ impl Default for State {
             graph: Default::default(),
             view: Default::default(),
             interaction: Default::default(),
+            node_color: Default::default(),
+            node_radius: 3.0,
             flow: egui::Direction::LeftToRight,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,10 +366,7 @@ impl Graph {
             let move_camera = match gmem.pressed.as_ref() {
                 None => false,
                 Some(p) => {
-                    let action_ok = match p.action {
-                        PressAction::DragNodes { ref node, .. } if node.is_none() => false,
-                        _ => true,
-                    };
+                    let action_ok = !matches!(p.action, PressAction::DragNodes { ref node, .. } if node.is_none());
                     action_ok && p.origin_pos != ptr_graph
                 }
             };

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,8 @@ pub struct Node {
     inputs: usize,
     outputs: usize,
     flow: egui::Direction,
+    node_radius: f32,
+    node_color: Option<egui::Color32>,
     max_width: Option<f32>,
 }
 
@@ -78,9 +80,11 @@ impl Node {
             id,
             frame: None,
             max_width: None,
+            node_color: None,
             inputs: 0,
             outputs: 0,
             flow: egui::Direction::LeftToRight,
+            node_radius: 3.0,
         }
     }
 
@@ -123,6 +127,18 @@ impl Node {
     /// Default direction is `LeftToRight`.
     pub fn flow(mut self, flow: egui::Direction) -> Self {
         self.flow = flow;
+        self
+    }
+
+    /// The color of the input and output nodes.
+    pub fn node_color(mut self, color: egui::Color32) -> Self {
+        self.node_color = Some(color);
+        self
+    }
+
+    /// The radius of the input and output nodes.
+    pub fn node_radius(mut self, radius: f32) -> Self {
+        self.node_radius = radius;
         self
     }
 
@@ -467,22 +483,22 @@ impl Node {
                 false
             };
 
-            let color = ui.visuals().text_color();
-            let rad = 3.0;
+            let color = self.node_color.unwrap_or(ui.visuals().text_color());
+            let hl_size = (self.node_radius + 4.0).max(4.0);
             for ix in 0..self.inputs {
                 if paint_highlight(SocketKind::Input, ix) {
                     ui.painter()
-                        .circle_filled(in_pos, rad * 3.0, color.linear_multiply(0.25));
+                        .circle_filled(in_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter().circle_filled(in_pos, rad, color);
+                ui.painter().circle_filled(in_pos, self.node_radius, color);
                 in_pos += in_step;
             }
             for ix in 0..self.outputs {
                 if paint_highlight(SocketKind::Output, ix) {
                     ui.painter()
-                        .circle_filled(out_pos, rad * 3.0, color.linear_multiply(0.25));
+                        .circle_filled(out_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter().circle_filled(out_pos, rad, color);
+                ui.painter().circle_filled(out_pos, self.node_radius, color);
                 out_pos += out_step;
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,8 +12,8 @@ pub struct Node {
     inputs: usize,
     outputs: usize,
     flow: egui::Direction,
-    node_radius: f32,
-    node_color: Option<egui::Color32>,
+    socket_radius: f32,
+    socket_color: Option<egui::Color32>,
     max_width: Option<f32>,
 }
 
@@ -80,11 +80,11 @@ impl Node {
             id,
             frame: None,
             max_width: None,
-            node_color: None,
+            socket_color: None,
             inputs: 0,
             outputs: 0,
             flow: egui::Direction::LeftToRight,
-            node_radius: 3.0,
+            socket_radius: 3.0,
         }
     }
 
@@ -130,15 +130,15 @@ impl Node {
         self
     }
 
-    /// The color of the input and output nodes.
-    pub fn node_color(mut self, color: egui::Color32) -> Self {
-        self.node_color = Some(color);
+    /// The color of the input and output sockets.
+    pub fn socket_color(mut self, color: egui::Color32) -> Self {
+        self.socket_color = Some(color);
         self
     }
 
-    /// The radius of the input and output nodes.
-    pub fn node_radius(mut self, radius: f32) -> Self {
-        self.node_radius = radius;
+    /// The radius of the input and output sockets.
+    pub fn socket_radius(mut self, radius: f32) -> Self {
+        self.socket_radius = radius;
         self
     }
 
@@ -483,14 +483,15 @@ impl Node {
                 false
             };
 
-            let color = self.node_color.unwrap_or(ui.visuals().text_color());
-            let hl_size = (self.node_radius + 4.0).max(4.0);
+            let color = self.socket_color.unwrap_or(ui.visuals().text_color());
+            let hl_size = (self.socket_radius + 4.0).max(4.0);
             for ix in 0..self.inputs {
                 if paint_highlight(SocketKind::Input, ix) {
                     ui.painter()
                         .circle_filled(in_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter().circle_filled(in_pos, self.node_radius, color);
+                ui.painter()
+                    .circle_filled(in_pos, self.socket_radius, color);
                 in_pos += in_step;
             }
             for ix in 0..self.outputs {
@@ -498,7 +499,8 @@ impl Node {
                     ui.painter()
                         .circle_filled(out_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter().circle_filled(out_pos, self.node_radius, color);
+                ui.painter()
+                    .circle_filled(out_pos, self.socket_radius, color);
                 out_pos += out_step;
             }
         }


### PR DESCRIPTION
Have updated the `bevy_demo` example with widgets for controlling 

- socket radius
- wire width
- socket color
- wire color

<img width="1071" alt="Screen Shot 2023-02-20 at 4 54 47 pm" src="https://user-images.githubusercontent.com/1289413/220020958-36b09225-5555-48b0-bbff-b9a22bd14d91.png">
