### PR TITLE
Add support for automated layout of graph nodes using layout-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ dependencies = [
  "bevy",
  "bevy_egui",
  "egui",
+ "layout-rs",
  "petgraph",
  "serde",
 ]
@@ -2240,6 +2241,12 @@ checksum = "87d65e08a9ec02e409d27a0139eaa6b9756b4d81fe7cde71f6941a83730ce838"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "layout-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1164ef87cb9607c2d887216eca79f0fc92895affe1789bba805dd38d829584e0"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 
 [dependencies]
 egui = { version = "0.23.0", default-features = false, optional = true }
+layout-rs = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -19,5 +20,6 @@ bevy_egui = "0.23.0"
 petgraph = "0.6"
 
 [features]
-default = ["serde"]
+default = ["layout", "serde"]
+layout = ["layout-rs"]
 serde = ["egui/serde", "dep:serde"]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,80 @@
+//! Items related to automated layout of nodes.
+
+use crate::Layout;
+use egui::Direction;
+use layout::{
+    core::{base::Orientation, geometry::Point, style::*},
+    std_shapes::shapes::*,
+    topo::{layout::VisualGraph, placer::Placer},
+};
+use std::collections::HashMap;
+
+/// Constructs a layout for a directed graph based on given edges and node sizes.
+///
+/// Returns a `Layout` object representing the positions of nodes in the graph.
+pub fn layout(
+    nodes: impl IntoIterator<Item = (egui::Id, egui::Vec2)>,
+    edges: impl IntoIterator<Item = (egui::Id, egui::Id)>,
+    flow: egui::Direction,
+) -> Layout {
+    let orientation = match flow {
+        Direction::LeftToRight | Direction::RightToLeft => Orientation::LeftToRight,
+        Direction::TopDown | Direction::BottomUp => Orientation::TopToBottom,
+    };
+    let mut vg = VisualGraph::new(orientation);
+
+    let mut handles = HashMap::new();
+    let mut ids = Vec::new();
+    for (id, size) in nodes {
+        let shape = ShapeKind::new_box("");
+        let style = StyleAttr::simple();
+        let size = Point::new(size.x.into(), size.y.into());
+        let node = Element::create(shape, style, orientation, size);
+        let handle = vg.add_node(node);
+        handles.insert(id, handle);
+        ids.push((handle, id));
+    }
+
+    for (a, b) in edges {
+        let edge = Arrow::default();
+        let na = handles[&a];
+        let nb = handles[&b];
+        vg.add_edge(edge, na, nb);
+    }
+
+    vg.to_valid_dag();
+    vg.split_text_edges();
+    let disable_opts = false;
+    vg.split_long_edges(disable_opts);
+    Placer::new(&mut vg).layout(true);
+
+    // `layout-rs` lays out nodes down and to the right starting from the middle.
+    // We find the bounding box and shift the nodes up and to the right in order
+    // to centre them under the default `camera` position.
+    let mut min = None;
+    let mut max = None;
+    let mut layout = Layout::new();
+    for (handle, id) in ids {
+        let pos = vg.pos(handle);
+        let with_halo = false;
+        let (tl, br) = pos.bbox(with_halo);
+        let pos = [tl.x as f32, tl.y as f32].into();
+        layout.insert(id, pos);
+        let [x, y] = min.get_or_insert([tl.x, tl.y]);
+        *x = x.min(tl.x);
+        *y = y.min(tl.y);
+        let [x, y] = max.get_or_insert([br.x, br.y]);
+        *x = x.max(br.x);
+        *y = y.max(br.y);
+    }
+    if let (Some(min), Some(max)) = (min, max) {
+        let half_w = ((max[0] - min[0]) / 2.0) as f32;
+        let half_h = ((max[1] - min[1]) / 2.0) as f32;
+        for p in layout.values_mut() {
+            p.x -= half_w;
+            p.y -= half_h;
+        }
+    }
+
+    layout
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "layout")]
+pub use layout::layout;
+
 pub mod bezier;
+#[cfg(feature = "layout")]
+pub mod layout;
 pub mod node;
 
 /// The main interface for the `Graph` widget.


### PR DESCRIPTION
Closes #8, but rather than using the `dot` CLI, we use the `layout-rs` crate's `VisualGraph` type. Rather than using one of `VisualGraph`'s rendering backends, we use the position information directly to layout the nodes within the egui graph.