### PR TITLE
Add node position interpolation animation param

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,7 @@ impl Graph {
                 width: 0.0,
                 ..vis.bg_stroke
             };
-            let fill = vis.bg_fill.linear_multiply(0.5);
+            let fill = vis.bg_fill;
             ui.painter().rect(full_rect, 0.0, fill, stroke);
         }
 


### PR DESCRIPTION
Allows for smoother positioning of nodes, useful when auto-layout is set.

Currently interpolates the x and y axes separately as egui only allows animating `bool`s or `f32`s.

TODO: Turn off the interpolation when the node is being dragged.

---

Also makes the graph background colour solid, otherwise demo window is semitransparent on wayland.