### PR TITLE
Improve node selection handling in demo

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -189,9 +189,7 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
 
         if response.changed() {
             // Update the selected nodes.
-            let gmem_arc = egui_graph::memory(ui, nctx.graph_id);
-            let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
-            if gmem.selection.nodes.contains(&egui_id) {
+            if egui_graph::is_node_selected(ui, nctx.graph_id, egui_id) {
                 state.interaction.selection.nodes.insert(n);
             } else {
                 state.interaction.selection.nodes.remove(&n);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use eframe::egui;
 use egui_graph::node::{EdgeEvent, SocketKind};
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -25,6 +25,7 @@ struct State {
     wire_width: f32,
     wire_color: egui::Color32,
     auto_layout: bool,
+    node_id_map: HashMap<egui::Id, NodeIndex>,
 }
 
 #[derive(Default)]
@@ -69,6 +70,7 @@ impl App {
             wire_color: ctx.style().visuals.weak_text_color(),
             flow: egui::Direction::TopDown,
             auto_layout: true,
+            node_id_map: Default::default(),
         };
         App { state }
     }
@@ -153,7 +155,9 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             .fold(0, |max, e| std::cmp::max(max, e.weight().0 + 1));
         let node = &mut state.graph[n];
         let graph_view = &mut state.view;
-        let response = egui_graph::node::Node::new(n)
+        let egui_id = egui::Id::new(n);
+        state.node_id_map.insert(egui_id, n);
+        let response = egui_graph::node::Node::from_id(egui_id)
             .inputs(inputs)
             .outputs(outputs)
             .flow(state.flow)
@@ -184,13 +188,13 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             });
 
         if response.changed() {
-            // Keep track of the selected nodes.
-            if let Some(selected) = response.selection() {
-                if selected {
-                    assert!(state.interaction.selection.nodes.insert(n));
-                } else {
-                    assert!(state.interaction.selection.nodes.remove(&n));
-                }
+            // Update the selected nodes.
+            let gmem_arc = egui_graph::memory(ui, nctx.graph_id);
+            let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
+            if gmem.selection.nodes.contains(&egui_id) {
+                state.interaction.selection.nodes.insert(n);
+            } else {
+                state.interaction.selection.nodes.remove(&n);
             }
 
             // Check for an edge event.
@@ -226,6 +230,7 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             // If the delete key was pressed while selected, remove it.
             if response.removed() {
                 state.graph.remove_node(n);
+                state.node_id_map.remove(&egui_id);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct GraphTempMemory {
     /// contents have been instantiated.
     node_sizes: HashMap<egui::Id, egui::Vec2>,
     /// The currently selected nodes and edges.
-    pub selection: Selection,
+    selection: Selection,
     /// Whether or not the primary button was pressed on the graph area and is still down.
     ///
     /// Used for tracking selection and dragging.
@@ -41,9 +41,9 @@ pub struct GraphTempMemory {
 }
 
 #[derive(Clone, Default)]
-pub struct Selection {
+struct Selection {
     /// The set of currently selected nodes.
-    pub nodes: HashSet<egui::Id>,
+    nodes: HashSet<egui::Id>,
     /// The set of currently selected edges.
     edges: HashSet<(node::Socket, node::Socket)>,
 }
@@ -737,8 +737,15 @@ pub fn id(id_src: impl Hash) -> egui::Id {
     egui::Id::new((std::any::TypeId::of::<Graph>(), id_src))
 }
 
+/// Checks if a node with the given ID is currently selected in the specified graph.
+pub fn is_node_selected(ui: &egui::Ui, graph_id: egui::Id, node_id: egui::Id) -> bool {
+    let gmem_arc = memory(ui, graph_id);
+    let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
+    gmem.selection.nodes.contains(&node_id)
+}
+
 /// Short-hand for retrieving access to the graph's temporary memory from the `Ui`.
-pub fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
+fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
     ui.ctx().data_mut(|d| {
         d.get_temp_mut_or_default::<Arc<Mutex<GraphTempMemory>>>(graph_id)
             .clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct GraphTempMemory {
     /// contents have been instantiated.
     node_sizes: HashMap<egui::Id, egui::Vec2>,
     /// The currently selected nodes and edges.
-    selection: Selection,
+    pub selection: Selection,
     /// Whether or not the primary button was pressed on the graph area and is still down.
     ///
     /// Used for tracking selection and dragging.
@@ -41,9 +41,9 @@ pub struct GraphTempMemory {
 }
 
 #[derive(Clone, Default)]
-struct Selection {
+pub struct Selection {
     /// The set of currently selected nodes.
-    nodes: HashSet<egui::Id>,
+    pub nodes: HashSet<egui::Id>,
     /// The set of currently selected edges.
     edges: HashSet<(node::Socket, node::Socket)>,
 }
@@ -155,7 +155,7 @@ pub struct Sockets {
 
 /// A context to assist with the instantiation of node widgets.
 pub struct NodesCtx<'a> {
-    graph_id: egui::Id,
+    pub graph_id: egui::Id,
     full_rect: egui::Rect,
     selection_rect: Option<egui::Rect>,
     select: bool,
@@ -738,7 +738,7 @@ pub fn id(id_src: impl Hash) -> egui::Id {
 }
 
 /// Short-hand for retrieving access to the graph's temporary memory from the `Ui`.
-fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
+pub fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
     ui.ctx().data_mut(|d| {
         d.get_temp_mut_or_default::<Arc<Mutex<GraphTempMemory>>>(graph_id)
             .clone()

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,8 +75,7 @@ impl Node {
     }
 
     // Construct the node directly from its `egui::Id`.
-    // TODO: Should this be exposed?
-    fn from_id(id: egui::Id) -> Self {
+    pub fn from_id(id: egui::Id) -> Self {
         Self {
             id,
             frame: None,


### PR DESCRIPTION
Sync demo's selection `HashSet<NodeIndex>` with egui_graph crate's selection logic. The selection logic in the demo now doesn't need reimplementing and can just be derived. 