### PR TITLE
refactor: Clean up lib.rs mod with pure functions, better field names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,13 +448,8 @@ impl Graph {
 
         // Draw the selection area if there is one.
         // TODO: Do this when `Show` is `drop`ped or finalised.
-        if let Some(r) = selection_rect {
-            let color = ui.visuals().weak_text_color();
-            let fill = color.linear_multiply(0.125);
-            let width = 1.0;
-            let stroke = egui::Stroke { width, color };
-            ui.painter()
-                .rect(r, 0.0, fill, stroke, egui::StrokeKind::Inside);
+        if let Some(sel_rect) = selection_rect {
+            paint_selection_area(sel_rect, ui);
         }
 
         // Create a child UI over the full surface of the graph widget.
@@ -743,6 +738,15 @@ fn paint_background(full_rect: egui::Rect, ui: &mut egui::Ui) {
     };
     let fill = vis.bg_fill;
     ui.painter().rect(full_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
+}
+
+/// Paint the selection area rectangle.
+fn paint_selection_area(sel_rect: egui::Rect, ui: &mut egui::Ui) {
+    let color = ui.visuals().weak_text_color();
+    let fill = color.linear_multiply(0.125);
+    let width = 1.0;
+    let stroke = egui::Stroke { width, color };
+    ui.painter().rect(sel_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
 }
 
 /// Combines the given id src with the `TypeId` of the `Graph` to produce a unique `egui::Id`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,28 +367,7 @@ impl Graph {
 
         // Paint some subtle dots to check camera movement.
         let visible_rect = egui::Rect::from_center_size(view.camera.pos, full_rect.size());
-        let dot_step = ui.spacing().interact_size.y;
-        let vis = ui.style().noninteractive();
-        let x_dots =
-            (visible_rect.min.x / dot_step) as i32..=(visible_rect.max.x / dot_step) as i32;
-        let y_dots =
-            (visible_rect.min.y / dot_step) as i32..=(visible_rect.max.y / dot_step) as i32;
-        let x_start = half_size.x - view.camera.pos.x;
-        let y_start = half_size.y - view.camera.pos.y;
-        for x_dot in x_dots {
-            for y_dot in y_dots.clone() {
-                let x = x_start + x_dot as f32 * dot_step;
-                let y = y_start + y_dot as f32 * dot_step;
-                let r = egui::Rect::from_center_size([x, y].into(), [1.0; 2].into());
-                let color = vis.bg_stroke.color;
-                let stroke = egui::Stroke {
-                    width: 0.0,
-                    ..vis.bg_stroke
-                };
-                ui.painter()
-                    .rect(r, 0.0, color, stroke, egui::StrokeKind::Inside);
-            }
-        }
+        paint_dot_grid(full_rect, visible_rect, view.camera.pos, ui);
 
         // Draw the selection area if there is one.
         // TODO: Do this when `Show` is `drop`ped or finalised.
@@ -746,15 +725,46 @@ fn find_closest_socket(
     closest_socket
 }
 
+// Paint a subtle dot grid to check camera movement.
+fn paint_dot_grid(
+    graph_rect: egui::Rect,
+    visible_rect: egui::Rect,
+    camera_pos: egui::Pos2,
+    ui: &mut egui::Ui,
+) {
+    let half_size = graph_rect.size() * 0.5;
+    let dot_step = ui.spacing().interact_size.y;
+    let vis = ui.style().noninteractive();
+    let x_dots = (visible_rect.min.x / dot_step) as i32..=(visible_rect.max.x / dot_step) as i32;
+    let y_dots = (visible_rect.min.y / dot_step) as i32..=(visible_rect.max.y / dot_step) as i32;
+    let x_start = half_size.x - camera_pos.x;
+    let y_start = half_size.y - camera_pos.y;
+    for x_dot in x_dots {
+        for y_dot in y_dots.clone() {
+            let x = x_start + x_dot as f32 * dot_step;
+            let y = y_start + y_dot as f32 * dot_step;
+            let r = egui::Rect::from_center_size([x, y].into(), [1.0; 2].into());
+            let color = vis.bg_stroke.color;
+            let stroke = egui::Stroke {
+                width: 0.0,
+                ..vis.bg_stroke
+            };
+            ui.painter()
+                .rect(r, 0.0, color, stroke, egui::StrokeKind::Inside);
+        }
+    }
+}
+
 // Paint the background rect.
-fn paint_background(full_rect: egui::Rect, ui: &mut egui::Ui) {
+fn paint_background(graph_rect: egui::Rect, ui: &mut egui::Ui) {
     let vis = ui.style().noninteractive();
     let stroke = egui::Stroke {
         width: 0.0,
         ..vis.bg_stroke
     };
     let fill = vis.bg_fill;
-    ui.painter().rect(full_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
+    ui.painter()
+        .rect(graph_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
 }
 
 /// Paint the selection area rectangle.
@@ -763,7 +773,8 @@ fn paint_selection_area(sel_rect: egui::Rect, ui: &mut egui::Ui) {
     let fill = color.linear_multiply(0.125);
     let width = 1.0;
     let stroke = egui::Stroke { width, color };
-    ui.painter().rect(sel_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
+    ui.painter()
+        .rect(sel_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
 }
 
 /// Combines the given id src with the `TypeId` of the `Graph` to produce a unique `egui::Id`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,14 +418,7 @@ impl Graph {
 
         // Paint the background rect.
         if self.background {
-            let vis = ui.style().noninteractive();
-            let stroke = egui::Stroke {
-                width: 0.0,
-                ..vis.bg_stroke
-            };
-            let fill = vis.bg_fill;
-            ui.painter()
-                .rect(full_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
+            paint_background(full_rect, ui);
         }
 
         // Paint some subtle dots to check camera movement.
@@ -739,6 +732,17 @@ impl Drop for Show {
     fn drop(&mut self) {
         self.prune_unused_nodes();
     }
+}
+
+// Paint the background rect.
+fn paint_background(full_rect: egui::Rect, ui: &mut egui::Ui) {
+    let vis = ui.style().noninteractive();
+    let stroke = egui::Stroke {
+        width: 0.0,
+        ..vis.bg_stroke
+    };
+    let fill = vis.bg_fill;
+    ui.painter().rect(full_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
 }
 
 /// Combines the given id src with the `TypeId` of the `Graph` to produce a unique `egui::Id`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub struct GraphTempMemory {
     ///
     /// Primarily used to check for node selection, as we don't know the size of the node until the
     /// contents have been instantiated.
-    node_sizes: HashMap<egui::Id, egui::Vec2>,
+    node_sizes: NodeSizes,
     /// The currently selected nodes and edges.
     selection: Selection,
     /// Whether or not the primary button was pressed on the graph area and is still down.
@@ -39,6 +39,8 @@ pub struct GraphTempMemory {
     /// Always `Some` while the pointer is over the graph area, `None` otherwise.
     closest_socket: Option<node::Socket>,
 }
+
+type NodeSizes = HashMap<egui::Id, egui::Vec2>;
 
 #[derive(Clone, Default)]
 struct Selection {

--- a/src/node.rs
+++ b/src/node.rs
@@ -181,10 +181,10 @@ impl Node {
         let target_pos_graph = layout.entry(self.id).or_insert_with(|| {
             // If the mouse is over the graph, add the node under the mouse.
             // Otherwise, add the node to the top-left.
-            let mut pos = camera.pos - ctx.full_rect.center() + ui.spacing().item_spacing;
-            if ui.rect_contains_pointer(ctx.full_rect) {
+            let mut pos = camera.pos - ctx.graph_rect.center() + ui.spacing().item_spacing;
+            if ui.rect_contains_pointer(ctx.graph_rect) {
                 ui.input(|i| i.pointer.hover_pos()).map(|ptr| {
-                    pos = ptr - ctx.full_rect.center() + camera.pos.to_vec2()
+                    pos = ptr - ctx.graph_rect.center() + camera.pos.to_vec2()
                         - ui.spacing().interact_size * 0.5;
                 });
             }
@@ -202,7 +202,7 @@ impl Node {
         };
 
         // Translate the graph position to a position within the UI.
-        let pos_screen = camera.graph_to_screen(ctx.full_rect, pos_graph);
+        let pos_screen = camera.graph_to_screen(ctx.graph_rect, pos_graph);
 
         // The window should always be at least the interaction size.
         let min_item_spacing = ui.spacing().item_spacing.x.min(ui.spacing().item_spacing.y);
@@ -233,7 +233,7 @@ impl Node {
         let mut frame = self.frame.unwrap_or_else(|| default_frame(ui.style()));
 
         let max_w = self.max_width.unwrap_or(ui.spacing().text_edit_width);
-        let max_size = egui::Vec2::new(max_w, ctx.full_rect.height());
+        let max_size = egui::Vec2::new(max_w, ctx.graph_rect.height());
 
         // Track changes in selection for the node response.
         let mut selection_changed = false;
@@ -339,7 +339,7 @@ impl Node {
                     // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
                     if gmem.pressed.is_none() {
                         let ptr_screen = ui.input(|i| i.pointer.hover_pos()).unwrap_or_default();
-                        let ptr_graph = view.camera.screen_to_graph(ctx.full_rect, ptr_screen);
+                        let ptr_graph = view.camera.screen_to_graph(ctx.graph_rect, ptr_screen);
                         gmem.pressed = Some(crate::Pressed {
                             over_selection_at_origin: true,
                             origin_pos: ptr_graph,


### PR DESCRIPTION
This is mostly some refactor work taken from #15 to land independently before re-approaching pan/zoom using the new `egui::containers::Scene` type.

The example was tested to ensure it behaves the same.