### PR TITLE
feat: Add support for panning and zooming the graph using `egui::Scene`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,19 +20,32 @@ checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
 dependencies = [
  "enumn",
  "serde",
 ]
 
 [[package]]
-name = "accesskit_atspi_common"
-version = "0.10.1"
+name = "accesskit_android"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
+checksum = "0af881ef4f4996d3cfc7333622e4f2f059c6b5a6749e286b6d7dae7b1e00ad72"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "jni",
+ "log",
+ "once_cell",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9928251cd5651ae983a77aeaa528471eed47cf705885e0b03249b72fe4e8e1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -44,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
 dependencies = [
  "accesskit",
  "hashbrown 0.15.2",
@@ -55,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -69,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
+checksum = "2ef06642e9f02f1708ad55e1eaeb8ad6956c22917699c4f313afa4f8f1b5e664"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -87,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "65178f3df98a51e4238e584fcb255cb1a4f9111820848eeddd37663be40a625f"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -102,11 +115,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "2c28531b0a1612b46d057a724a1e3de42a4bb101ff9f18c96c32f605b6e5ef06"
 dependencies = [
  "accesskit",
+ "accesskit_android",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -385,9 +399,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -396,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
@@ -412,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -424,14 +438,13 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
- "zvariant",
 ]
 
 [[package]]
@@ -475,15 +488,6 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block2"
@@ -696,15 +700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,30 +718,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dispatch"
@@ -787,8 +762,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "bytemuck",
  "emath",
@@ -798,8 +772,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dfe0859f3fb1bc6424c57d41e10e9093fe938f426b691e42272c2f336d915c"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -834,8 +807,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "accesskit",
  "ahash",
@@ -851,8 +823,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d319dfef570f699b6e9114e235e862a2ddcf75f0d1a061de9e1328d92146d820"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -871,8 +842,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9dfbb78fe4eb9c3a39ad528b90ee5915c252e77bbab9d4ebc576541ab67e13"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -891,8 +861,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -921,8 +890,7 @@ dependencies = [
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "bytemuck",
  "serde",
@@ -982,8 +950,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1001,8 +968,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
+source = "git+https://github.com/mitchmindtree/egui.git?branch=scene-drag-pan-buttons#82f2bdec5daafcfc3180a9abf5dafe8d19cb77be"
 
 [[package]]
 name = "equivalent"
@@ -1176,12 +1142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,24 +1154,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2189,12 +2136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,9 +2161,9 @@ checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -2244,36 +2185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -2432,17 +2343,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2752,12 +2652,6 @@ checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
 dependencies = [
  "rustc-hash",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uds_windows"
@@ -3657,9 +3551,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3674,19 +3568,17 @@ dependencies = [
  "enumflags2",
  "event-listener 5.4.0",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
- "rand",
  "serde",
  "serde_repr",
- "sha1",
  "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+ "winnow",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -3695,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "a22426b1bc2aca91de97772506f0655fa373448e6010d79d5d5880915c388409"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -3705,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "100ffec29ed51859052f4563061abe35557acb56ba574510571f8398efc70a29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3719,35 +3611,38 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
 dependencies = [
- "quick-xml 0.30.0",
+ "quick-xml 0.36.2",
  "serde",
  "static_assertions",
  "zbus_names",
@@ -3776,22 +3671,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
+ "winnow",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3802,11 +3699,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "static_assertions",
  "syn",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ repository = "https://github.com/nannou-org/nannou.git"
 resolver = "2"
 
 [dependencies]
-egui = { version = "0.31.1", default-features = false, optional = true }
+# egui = { version = "0.31.1", default-features = false, optional = true }
+egui = { git = "https://github.com/mitchmindtree/egui.git", branch = "scene-drag-pan-buttons", default-features = false, optional = true }
 layout-rs = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-eframe = "0.31.1"
+# eframe = "0.31.1"
+eframe = { git = "https://github.com/mitchmindtree/egui.git", branch = "scene-drag-pan-buttons" }
 env_logger = "0.10"
 petgraph = "0.6"
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -27,6 +27,7 @@ struct State {
     auto_layout: bool,
     node_spacing: [f32; 2],
     node_id_map: HashMap<egui::Id, NodeIndex>,
+    center_view: bool,
 }
 
 #[derive(Default)]
@@ -72,6 +73,7 @@ impl App {
             auto_layout: true,
             node_spacing: [1.0, 1.0],
             node_id_map: Default::default(),
+            center_view: false,
         };
         let view = Default::default();
         App { view, state }
@@ -154,10 +156,12 @@ fn gui(ctx: &egui::Context, view: &mut egui_graph::View, state: &mut State) {
 }
 
 fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
-    egui_graph::Graph::new("Demo Graph").show(view, ui, |ui, show| {
-        show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
-            .edges(ui, |ectx, ui| edges(ectx, ui, state));
-    });
+    egui_graph::Graph::new("Demo Graph")
+        .center_view(state.center_view)
+        .show(view, ui, |ui, show| {
+            show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
+                .edges(ui, |ectx, ui| edges(ectx, ui, state));
+        });
 }
 
 fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) {
@@ -353,6 +357,7 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
                     }
                 });
             });
+            ui.checkbox(&mut state.center_view, "Center View");
             ui.horizontal(|ui| {
                 ui.label("Flow:");
                 ui.radio_value(&mut state.flow, egui::Direction::LeftToRight, "Right");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -258,9 +258,13 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         color: state.wire_color,
     };
 
-    let mouse_pos = ui.input(|i| i.pointer.interact_pos().unwrap_or_default());
+    let response = ui.response();
+    let mouse_pos = response
+        .interact_pointer_pos()
+        .or(response.hover_pos())
+        .unwrap_or_default();
     let click = ui.input(|i| i.pointer.any_released());
-    let shift_held = ui.input(|i| i.modifiers.shift);
+    let shift_held = ui.input(|i| i.modifiers.ctrl);
     let mut clicked_on_edge = false;
     let selection_threshold = state.wire_width * 8.0; // Threshold for selecting the edge
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -376,5 +376,6 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
                 ui.label("Socket color:");
                 ui.color_edit_button_srgba(&mut state.socket_color);
             });
+            ui.label(format!("Scene: {:?}", view.scene_rect));
         });
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -80,7 +80,6 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        gui(ctx, &mut self.view, &mut self.state);
         if self.state.auto_layout {
             self.view.layout = layout(
                 &self.state.graph,
@@ -89,6 +88,7 @@ impl eframe::App for App {
                 ctx,
             );
         }
+        gui(ctx, &mut self.view, &mut self.state);
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -267,9 +267,9 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         .interact_pointer_pos()
         .or(response.hover_pos())
         .unwrap_or_default();
-    let click = ui.input(|i| i.pointer.any_released());
+    let primary_released = ui.input(|i| i.pointer.primary_released());
     let shift_held = ui.input(|i| i.modifiers.ctrl);
-    let mut clicked_on_edge = false;
+    let mut primary_released_on_edge = false;
     let selection_threshold = state.wire_width * 8.0; // Threshold for selecting the edge
 
     for e in indices {
@@ -286,8 +286,8 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         // Check if mouse is over the bezier curve
         let closest_point = bezier.closest_point(dist_per_pt, egui::Pos2::from(mouse_pos));
         let distance_to_mouse = closest_point.distance(egui::Pos2::from(mouse_pos));
-        if distance_to_mouse < selection_threshold && click {
-            clicked_on_edge = true;
+        if distance_to_mouse < selection_threshold && primary_released {
+            primary_released_on_edge = true;
             // If Shift is not held, clear previous selection
             if !shift_held {
                 state.interaction.selection.edges.clear();
@@ -310,7 +310,7 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
             .add(egui::Shape::line(pts.clone(), wire_stroke));
     }
 
-    if click && !clicked_on_edge {
+    if primary_released && !primary_released_on_edge {
         // Click occurred on the canvas, clear the selection
         state.interaction.selection.edges.clear();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod node;
 pub struct Graph {
     background: bool,
     zoom_range: egui::Rangef,
+    max_inner_size: Option<egui::Vec2>,
     id: egui::Id,
 }
 
@@ -192,6 +193,7 @@ impl Graph {
         Self {
             background: true,
             zoom_range: Self::DEFAULT_ZOOM_RANGE,
+            max_inner_size: None,
             id: id(id_src),
         }
     }
@@ -212,6 +214,13 @@ impl Graph {
         self
     }
 
+    /// Set the maximum size of the scene's inner [`Ui`] that will be created.
+    #[inline]
+    pub fn max_inner_size(mut self, max_inner_size: impl Into<egui::Vec2>) -> Self {
+        self.max_inner_size = Some(max_inner_size.into());
+        self
+    }
+
     /// Begin showing the parts of the Graph.
     pub fn show(
         self,
@@ -227,8 +236,12 @@ impl Graph {
             ref mut layout,
         } = *view;
 
-        // TODO: make zoom_range a graph argument.
-        let scene = egui::containers::Scene::new().zoom_range(self.zoom_range.clone());
+        // Create the Scene.
+        let mut scene = egui::containers::Scene::new().zoom_range(self.zoom_range.clone());
+        if let Some(max_inner_size) = self.max_inner_size {
+            scene = scene.max_inner_size(max_inner_size);
+        }
+
         scene.show(ui, scene_rect, |ui| {
             // Draw the selection rectangle if there is one.
             let mut selection_rect = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ impl Graph {
 
                 // Check for the closest socket.
                 let closest_socket = match ptr_on_graph {
-                    true => find_closest_socket(ptr_graph, graph_rect, layout, &gmem, ui)
+                    true => find_closest_socket(ptr_graph, layout, &gmem, ui)
                         .map(|(socket, _dist_sqrd)| socket),
                     false => None,
                 };
@@ -594,8 +594,7 @@ impl Default for View {
 ///
 /// Returns the socket alongside the squared distance from the socket.
 fn find_closest_socket(
-    pos_screen: egui::Pos2,
-    graph_rect: egui::Rect,
+    pos_graph: egui::Pos2,
     layout: &Layout,
     gmem: &GraphTempMemory,
     ui: &egui::Ui,
@@ -608,6 +607,7 @@ fn find_closest_socket(
         .interact_size
         .x
         .min(ui.spacing().interact_size.y);
+    let visible_rect = ui.clip_rect();
     let socket_radius_sq = socket_radius * socket_radius;
     for (&n_id, &n_graph) in layout {
         // Only check visible nodes.
@@ -617,7 +617,7 @@ fn find_closest_socket(
             Some(&size) => size,
         };
         let rect = egui::Rect::from_min_size(n_screen, size);
-        if !graph_rect.intersects(rect) {
+        if !visible_rect.intersects(rect) {
             continue;
         }
         let sockets = match gmem.sockets.get(&n_id) {
@@ -627,7 +627,7 @@ fn find_closest_socket(
 
         // Check inputs.
         for (ix, (p, _)) in sockets.inputs().enumerate() {
-            let dist_sq = pos_screen.distance_sq(p);
+            let dist_sq = pos_graph.distance_sq(p);
             if dist_sq < socket_radius_sq {
                 let socket = node::Socket {
                     node: n_id,
@@ -644,7 +644,7 @@ fn find_closest_socket(
 
         // Check outputs.
         for (ix, (p, _)) in sockets.outputs().enumerate() {
-            let dist_sq = pos_screen.distance_sq(p);
+            let dist_sq = pos_graph.distance_sq(p);
             if dist_sq < socket_radius_sq {
                 let socket = node::Socket {
                     node: n_id,
@@ -810,7 +810,7 @@ fn paint_dot_grid(visible_rect: egui::Rect, ui: &mut egui::Ui) {
 }
 
 // Paint the background rect.
-fn paint_background(graph_rect: egui::Rect, ui: &mut egui::Ui) {
+fn paint_background(visible_rect: egui::Rect, ui: &mut egui::Ui) {
     let vis = ui.style().noninteractive();
     let stroke = egui::Stroke {
         width: 0.0,
@@ -818,7 +818,7 @@ fn paint_background(graph_rect: egui::Rect, ui: &mut egui::Ui) {
     };
     let fill = vis.bg_fill;
     ui.painter()
-        .rect(graph_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
+        .rect(visible_rect, 0.0, fill, stroke, egui::StrokeKind::Inside);
 }
 
 /// Paint the selection area rectangle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,9 +205,8 @@ impl Graph {
             ref mut layout,
         } = *view;
 
-        let visible_rect = *scene_rect;
-        println!("before: {:?}", *scene_rect);
-        egui::containers::Scene::new().show(ui, scene_rect, |ui| {
+        // TODO: make zoom_range a graph argument.
+        egui::containers::Scene::new().zoom_range(0.5..=2.0).show(ui, scene_rect, |ui| {
             // Draw the selection rectangle if there is one.
             let mut selection_rect = None;
             let mut select = false;
@@ -266,31 +265,16 @@ impl Graph {
                 selection_rect = interaction.selection_rect;
                 select = interaction.select;
                 socket_press_released = interaction.socket_press_released;
-
-                // If the pointer is down and near an edge of the rect, move the camera in that
-                // direction.
-                // if drag_moves_camera(gmem.pressed.as_ref(), ptr_graph) {
-                //     camera.pos += drag_moves_camera_velocity(graph_rect, ptr_screen, ui);
-                // }
             }
 
-            // // Check if we should drag or scroll the camera position.
-            // if !ptr_in_use && ptr_on_graph {
-            //     ui.input(|i| {
-            //         // Middle mouse button moves camera.
-            //         if i.pointer.is_moving() && i.pointer.button_down(egui::PointerButton::Middle) {
-            //             camera.pos -= pointer.delta();
-            //         }
-            //     });
-            // }
-
             // Paint the background rect.
+            let visible_rect = ui.clip_rect();
             if self.background {
-                paint_background(graph_rect, ui);
+                paint_background(visible_rect, ui);
             }
 
             // Paint some subtle dots to check camera movement.
-            paint_dot_grid(graph_rect, ui);
+            paint_dot_grid(visible_rect, ui);
 
             // Draw the selection area if there is one.
             // TODO: Do this when `Show` is `drop`ped or finalised.
@@ -318,7 +302,6 @@ impl Graph {
 
             prune_unused_nodes(self.id, &visited, ui);
         });
-        println!("after: {:?}", *scene_rect);
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -167,8 +167,7 @@ impl Node {
         ui: &mut egui::Ui,
         content: Box<dyn FnOnce(&mut egui::Ui) + 'a>,
     ) -> NodeResponse {
-        let layout = &mut ctx.view.layout;
-        let camera = &ctx.view.camera;
+        let layout = &mut ctx.layout;
 
         // Indicate that we've visited this node this update.
         ctx.visited.insert(self.id);
@@ -176,11 +175,10 @@ impl Node {
         let target_pos_graph = layout.entry(self.id).or_insert_with(|| {
             // If the mouse is over the graph, add the node under the mouse.
             // Otherwise, add the node to the top-left.
-            let mut pos = camera.pos - ctx.graph_rect.center() + ui.spacing().item_spacing;
+            let mut pos = ctx.graph_rect.center();
             if ui.rect_contains_pointer(ctx.graph_rect) {
                 ui.input(|i| i.pointer.hover_pos()).map(|ptr| {
-                    pos = ptr - ctx.graph_rect.center() + camera.pos.to_vec2()
-                        - ui.spacing().interact_size * 0.5;
+                    pos = ptr;
                 });
             }
             egui::Pos2::new(pos.x, pos.y)
@@ -197,7 +195,7 @@ impl Node {
         };
 
         // Translate the graph position to a position within the UI.
-        let pos_screen = camera.graph_to_screen(ctx.graph_rect, pos_graph);
+        let pos_screen = pos_graph;
 
         // The window should always be at least the interaction size.
         let min_item_spacing = ui.spacing().item_spacing.x.min(ui.spacing().item_spacing.y);
@@ -334,7 +332,7 @@ impl Node {
                     // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
                     if gmem.pressed.is_none() {
                         let ptr_screen = ui.input(|i| i.pointer.hover_pos()).unwrap_or_default();
-                        let ptr_graph = camera.screen_to_graph(ctx.graph_rect, ptr_screen);
+                        let ptr_graph = ptr_screen;
                         gmem.pressed = Some(crate::Pressed {
                             over_selection_at_origin: true,
                             origin_pos: ptr_graph,

--- a/src/node.rs
+++ b/src/node.rs
@@ -283,9 +283,19 @@ impl Node {
         let put_size = egui::Vec2::new(max_size.x, min_size.y);
         let put_rect = egui::Rect::from_min_size(pos_screen, put_size);
 
+        // Put the node's frame on a layer above the scene's UI layer.
+        let scene_layer = ui.layer_id();
+        let frame_layer = egui::LayerId::new(scene_layer.order, self.id);
+        ui.ctx().set_sublayer(scene_layer, frame_layer);
+        // let transform = ui.ctx().layer_transform_to_global(scene_layer).unwrap();
+        // ui.ctx().set_transform_layer(frame_layer, transform);
+        ui.ctx()
+            .set_transform_layer(frame_layer, ctx.scene_to_global);
+
         // A `Ui` scope for placing the `Frame`.
         let builder = egui::UiBuilder::new()
             .max_rect(put_rect)
+            .layer_id(frame_layer)
             .sense(egui::Sense::click_and_drag());
         let inner_response = ui.scope_builder(builder, |ui| {
             // Show the frame.
@@ -296,7 +306,6 @@ impl Node {
                     // Set the user's content.
                     content(ui);
                 });
-
                 inner_response.response
             });
 
@@ -512,22 +521,19 @@ impl Node {
 
             let color = self.socket_color.unwrap_or(ui.visuals().text_color());
             let hl_size = (self.socket_radius + 4.0).max(4.0);
+            let painter = ui.painter();
             for ix in 0..self.inputs {
                 if paint_highlight(SocketKind::Input, ix) {
-                    ui.painter()
-                        .circle_filled(in_pos, hl_size, color.linear_multiply(0.25));
+                    painter.circle_filled(in_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter()
-                    .circle_filled(in_pos, self.socket_radius, color);
+                painter.circle_filled(in_pos, self.socket_radius, color);
                 in_pos += in_step;
             }
             for ix in 0..self.outputs {
                 if paint_highlight(SocketKind::Output, ix) {
-                    ui.painter()
-                        .circle_filled(out_pos, hl_size, color.linear_multiply(0.25));
+                    painter.circle_filled(out_pos, hl_size, color.linear_multiply(0.25));
                 }
-                ui.painter()
-                    .circle_filled(out_pos, self.socket_radius, color);
+                painter.circle_filled(out_pos, self.socket_radius, color);
                 out_pos += out_step;
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -154,29 +154,24 @@ impl Node {
     /// Present the `Node`'s `Window` and add the given contents.
     pub fn show(
         self,
-        view: &mut crate::View,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
         content: impl FnOnce(&mut egui::Ui),
     ) -> NodeResponse {
-        self.show_impl(view, ctx, ui, Box::new(content) as Box<_>)
+        self.show_impl(ctx, ui, Box::new(content) as Box<_>)
     }
 
     fn show_impl<'a>(
         self,
-        view: &mut crate::View,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
         content: Box<dyn FnOnce(&mut egui::Ui) + 'a>,
     ) -> NodeResponse {
-        let crate::View {
-            ref mut layout,
-            ref camera,
-        } = *view;
+        let layout = &mut ctx.view.layout;
+        let camera = &ctx.view.camera;
 
         // Indicate that we've visited this node this update.
         ctx.visited.insert(self.id);
-
         // Determine the current position of the window relative to the graph origin.
         let target_pos_graph = layout.entry(self.id).or_insert_with(|| {
             // If the mouse is over the graph, add the node under the mouse.
@@ -339,7 +334,7 @@ impl Node {
                     // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
                     if gmem.pressed.is_none() {
                         let ptr_screen = ui.input(|i| i.pointer.hover_pos()).unwrap_or_default();
-                        let ptr_graph = view.camera.screen_to_graph(ctx.graph_rect, ptr_screen);
+                        let ptr_graph = camera.screen_to_graph(ctx.graph_rect, ptr_screen);
                         gmem.pressed = Some(crate::Pressed {
                             over_selection_at_origin: true,
                             origin_pos: ptr_graph,

--- a/src/node.rs
+++ b/src/node.rs
@@ -293,8 +293,9 @@ impl Node {
         let scene_layer = ui.layer_id();
         let frame_layer = egui::LayerId::new(scene_layer.order, self.id);
         ui.ctx().set_sublayer(scene_layer, frame_layer);
-        ui.ctx()
-            .set_transform_layer(frame_layer, ctx.scene_to_global);
+        if let Some(transform) = ui.ctx().layer_transform_to_global(scene_layer) {
+            ui.ctx().set_transform_layer(frame_layer, transform);
+        }
 
         // A `Ui` scope for placing the `Frame`.
         let builder = egui::UiBuilder::new()

--- a/src/node.rs
+++ b/src/node.rs
@@ -284,31 +284,25 @@ impl Node {
         let put_rect = egui::Rect::from_min_size(pos_screen, put_size);
 
         // A `Ui` scope for placing the `Frame`.
-        let inner_response = ui.scope_builder(
-            egui::UiBuilder::new()
-                .max_rect(put_rect)
-                .sense(egui::Sense::click_and_drag()),
-            |ui: &mut egui::Ui| -> egui::Response {
-                // Show the frame.
-                let inner_response = frame.show(ui, |ui| {
-                    // Create a child UI that can be clicked and dragged.
-                    let scope_response = ui
-                        .scope_builder(
-                            egui::UiBuilder::new().sense(egui::Sense::click_and_drag()),
-                            |ui| {
-                                // Set the user's content.
-                                content(ui);
-                            },
-                        )
-                        .response;
-
-                    scope_response
+        let builder = egui::UiBuilder::new()
+            .max_rect(put_rect)
+            .sense(egui::Sense::click_and_drag());
+        let inner_response = ui.scope_builder(builder, |ui| {
+            // Show the frame.
+            let inner_response = frame.show(ui, |ui| {
+                // Create a node content UI that can be clicked and dragged.
+                let builder = egui::UiBuilder::new().sense(egui::Sense::click_and_drag());
+                let inner_response = ui.scope_builder(builder, |ui| {
+                    // Set the user's content.
+                    content(ui);
                 });
 
-                // Merge the content area response with the frame response.
-                inner_response.response.union(inner_response.inner)
-            },
-        );
+                inner_response.response
+            });
+
+            // Merge the content area response with the frame response.
+            inner_response.response.union(inner_response.inner)
+        });
         let mut response = inner_response.response.union(inner_response.inner);
 
         // Update the stored data for this node and check for edge events.

--- a/src/node.rs
+++ b/src/node.rs
@@ -176,11 +176,12 @@ impl Node {
         let target_pos_graph = layout.entry(self.id).or_insert_with(|| {
             // If the mouse is over the graph, add the node under the mouse.
             // Otherwise, add the node to the top-left.
-            let mut pos = ctx.graph_rect.center();
-            if ui.rect_contains_pointer(ctx.graph_rect) {
-                ui.input(|i| i.pointer.hover_pos()).map(|ptr| {
+            let clip_rect = ui.clip_rect();
+            let mut pos = clip_rect.center();
+            if ui.rect_contains_pointer(clip_rect) {
+                if let Some(ptr) = ui.response().hover_pos() {
                     pos = ptr;
-                });
+                }
             }
             egui::Pos2::new(pos.x, pos.y)
         });
@@ -228,7 +229,7 @@ impl Node {
                 }
             }
         }
-        // Retrieve the frame for the window.
+        // Retrieve the frame.
         let mut frame = self.frame.unwrap_or_else(|| default_frame(ui.style()));
 
         let max_w = self.max_width.unwrap_or(ui.spacing().text_edit_width);
@@ -238,8 +239,8 @@ impl Node {
         let mut selection_changed = false;
 
         // Determine whether or not this node is within the selection rect.
-        // NOTE: We use the size from last frame as we don't know the size until the user's content
-        // is added... Is there a better way to handle this?
+        // NOTE: We use the size from last frame as we don't know the size until
+        // the user's content is added... Is there a better way to handle this?
         let (mut selected, in_selection_rect) = {
             let gmem_arc = crate::memory(ui, ctx.graph_id);
             let mut gmem = gmem_arc.lock().expect("failed to lock graph temp memory");

--- a/src/node.rs
+++ b/src/node.rs
@@ -308,6 +308,11 @@ impl Node {
                 // Create a node content UI that can be clicked and dragged.
                 let builder = egui::UiBuilder::new().sense(egui::Sense::click_and_drag());
                 let inner_response = ui.scope_builder(builder, |ui| {
+                    // Set the minimum size required to layout the sockets.
+                    let gap = egui::Vec2::splat(win_corner_radius * 2.0);
+                    let min_size = min_size - gap;
+                    ui.set_min_size(min_size);
+
                     // Set the user's content.
                     content(ui);
                 });

--- a/src/node.rs
+++ b/src/node.rs
@@ -401,6 +401,7 @@ impl Node {
         }
 
         if response.rect.min != pos_screen {
+            // NOTE: This doesn't appear to be doing anything.
             *target_pos_graph += response.rect.min - pos_screen;
             response.mark_changed();
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -293,8 +293,6 @@ impl Node {
         let scene_layer = ui.layer_id();
         let frame_layer = egui::LayerId::new(scene_layer.order, self.id);
         ui.ctx().set_sublayer(scene_layer, frame_layer);
-        // let transform = ui.ctx().layer_transform_to_global(scene_layer).unwrap();
-        // ui.ctx().set_transform_layer(frame_layer, transform);
         ui.ctx()
             .set_transform_layer(frame_layer, ctx.scene_to_global);
 
@@ -346,8 +344,7 @@ impl Node {
                     selected = true;
                     // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
                     if gmem.pressed.is_none() {
-                        let ptr_screen = ui.input(|i| i.pointer.hover_pos()).unwrap_or_default();
-                        let ptr_graph = ptr_screen;
+                        let ptr_graph = response.hover_pos().unwrap_or_default();
                         gmem.pressed = Some(crate::Pressed {
                             over_selection_at_origin: true,
                             origin_pos: ptr_graph,


### PR DESCRIPTION
This adds support for panning and zooming the graph using `egui::Scene`.

This PR is based on a fork of egui for the following changes:

- https://github.com/emilk/egui/pull/5791
- https://github.com/emilk/egui/pull/5884
- https://github.com/emilk/egui/pull/5892

As a result, I'll merge this PR into a new `develop` branch for now rather than `main`.

Once emilk/egui#5892 lands and gets published, we can update again and merge `develop` into `main`.

## To-Do

- [x] Change `Node`s from `Window` to some other area (or new widget) that respects `Scene` UI.
- [x] Fix background (currently offset by half the size of the window).
- [x] Fix dot grid.
- [x] Fix `Sense` behaviour between 1. A node's children, 2. the node's frame and 3. the `Scene` on which nodes are placed.
    - Potentially solvable by first allocating a response for the `Frame`, then instantiating a child UI on top for node content.
- [x] Fix issue where some widgets take more space than they need (label, button).
- [x] Draw edges behind nodes.
    - Maybe make the node layer a sublayer of the scene [like this](https://docs.rs/egui/latest/src/egui/containers/scene.rs.html#135-151) so that it's on-top?
- [x] ~Fix interaction on text edit node.~
    - EDIT: fixed on master as of https://github.com/emilk/egui/pull/5791.
- [x] Fix initial `Scene` offset. The view currently starts too far to the right of the content.
    - Might be due to the way we auto-layout nodes with `[0, 0]` as centre, rather than down and to the right?
- [x] Fix drag behaviour to conform to current transform i.e. zoom level.
- [x] Make scene zoom_range a graph parameter.
- [x] Change primary-click back to doing node-selection. Only pan camera on middle click drag or scroll.
    - This is causing the primary click drag I think: https://docs.rs/egui/latest/src/egui/containers/scene.rs.html#150
- [x] Get edge creation working again (check that it was working before).
- [x] Get basic edge selection working in example again.
- [x] Initialise zoom to 1.0, even if fitting content would indicate different zoom.
- [x] Clean-up old camera-related bindings and comments.
    - There are a few assignments that are basically just renames now that used to be position transforms - should remove these.