### PR TITLE
Add an `Edge` widget to simplify `edges` in demo. Add support for rectangular selection of multiple edges with shift.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -298,11 +298,7 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
 
     // Draw the in-progress edge if there is one.
     if let Some(edge) = ectx.in_progress(ui) {
-        let bezier = edge.bezier_cubic();
-        let dist_per_pt = 5.0;
-        let pts = bezier.flatten(dist_per_pt).collect();
-        let stroke = ui.visuals().widgets.active.fg_stroke;
-        ui.painter().add(egui::Shape::line(pts, stroke));
+        edge.show(ui);
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -22,8 +22,9 @@ struct State {
     flow: egui::Direction,
     socket_radius: f32,
     socket_color: egui::Color32,
-    wire_width: f32,
-    wire_color: egui::Color32,
+    custom_edge_style: bool,
+    edge_width: f32,
+    edge_color: egui::Color32,
     auto_layout: bool,
     node_spacing: [f32; 2],
     node_id_map: HashMap<egui::Id, NodeIndex>,
@@ -67,8 +68,9 @@ impl App {
             interaction: Default::default(),
             socket_color: ctx.style().visuals.weak_text_color(),
             socket_radius: 3.0,
-            wire_width: 1.0,
-            wire_color: ctx.style().visuals.weak_text_color(),
+            custom_edge_style: false,
+            edge_width: 1.0,
+            edge_color: ctx.style().visuals.weak_text_color(),
             flow: egui::Direction::TopDown,
             auto_layout: true,
             node_spacing: [1.0, 1.0],
@@ -160,8 +162,25 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
         .center_view(state.center_view)
         .show(view, ui, |ui, show| {
             show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
-                .edges(ui, |ectx, ui| edges(ectx, ui, state));
+                .edges(ui, |ectx, ui| {
+                    if state.custom_edge_style {
+                        set_edge_style(ui.style_mut(), state);
+                    }
+                    edges(ectx, ui, state)
+                });
         });
+}
+
+fn set_edge_style(style: &mut egui::Style, state: &mut State) {
+    let vis_mut = &mut style.visuals;
+    // Edges use `noninteractive` by default, `hovered` when hovered.
+    vis_mut.widgets.noninteractive.fg_stroke.color = state.edge_color;
+    vis_mut.widgets.noninteractive.fg_stroke.width = state.edge_width;
+    vis_mut.widgets.hovered.fg_stroke.color = state.edge_color.linear_multiply(1.25);
+    vis_mut.widgets.hovered.fg_stroke.width = state.edge_width;
+    // Exaggerate the color and width when selected.
+    vis_mut.selection.stroke.color = state.edge_color.linear_multiply(1.5);
+    vis_mut.selection.stroke.width = state.edge_width * 3.0;
 }
 
 fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) {
@@ -255,64 +274,26 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
 }
 
 fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) {
-    // Draw the attached edges.
-    let indices: Vec<_> = state.graph.edge_indices().collect();
-    let stroke = egui::Stroke {
-        width: state.wire_width,
-        color: state.wire_color,
-    };
-
-    let response = ui.response();
-    let mouse_pos = response
-        .interact_pointer_pos()
-        .or(response.hover_pos())
-        .unwrap_or_default();
-    let primary_released = ui.input(|i| i.pointer.primary_released());
-    let shift_held = ui.input(|i| i.modifiers.ctrl);
-    let mut primary_released_on_edge = false;
-    let selection_threshold = state.wire_width * 8.0; // Threshold for selecting the edge
-
-    for e in indices {
+    // Instantiate all edges.
+    for e in state.graph.edge_indices().collect::<Vec<_>>() {
         let (na, nb) = state.graph.edge_endpoints(e).unwrap();
         let (output, input) = *state.graph.edge_weight(e).unwrap();
         let a = egui::Id::new(na);
         let b = egui::Id::new(nb);
-        let a_out = ectx.output(ui, a, output).unwrap();
-        let b_in = ectx.input(ui, b, input).unwrap();
-        let bezier = egui_graph::bezier::Cubic::from_edge_points(a_out, b_in);
-        let dist_per_pt = 5.0;
-        let pts: Vec<_> = bezier.flatten(dist_per_pt).collect();
+        let mut selected = state.interaction.selection.edges.contains(&e);
+        let response =
+            egui_graph::edge::Edge::new((a, output), (b, input), &mut selected).show(ectx, ui);
 
-        // Check if mouse is over the bezier curve
-        let closest_point = bezier.closest_point(dist_per_pt, egui::Pos2::from(mouse_pos));
-        let distance_to_mouse = closest_point.distance(egui::Pos2::from(mouse_pos));
-        if distance_to_mouse < selection_threshold && primary_released {
-            primary_released_on_edge = true;
-            // If Shift is not held, clear previous selection
-            if !shift_held {
-                state.interaction.selection.edges.clear();
+        if response.deleted() {
+            state.graph.remove_edge(e);
+            state.interaction.selection.edges.remove(&e);
+        } else if response.changed() {
+            if selected {
+                state.interaction.selection.edges.insert(e);
+            } else {
+                state.interaction.selection.edges.remove(&e);
             }
-            // Add the clicked edge to the selection
-            state.interaction.selection.edges.insert(e);
         }
-
-        let wire_stroke = if state.interaction.selection.edges.contains(&e) {
-            egui::Stroke {
-                width: state.wire_width * 4.0,
-                color: state.wire_color.linear_multiply(1.5),
-            }
-        } else {
-            stroke
-        };
-
-        // Draw the bezier curve
-        ui.painter()
-            .add(egui::Shape::line(pts.clone(), wire_stroke));
-    }
-
-    if primary_released && !primary_released_on_edge {
-        // Click occurred on the canvas, clear the selection
-        state.interaction.selection.edges.clear();
     }
 
     // Draw the in-progress edge if there is one.
@@ -320,15 +301,8 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let bezier = edge.bezier_cubic();
         let dist_per_pt = 5.0;
         let pts = bezier.flatten(dist_per_pt).collect();
+        let stroke = ui.visuals().widgets.active.fg_stroke;
         ui.painter().add(egui::Shape::line(pts, stroke));
-    }
-
-    // Remove selected edges if delete/backspace is pressed
-    if ui.input(|i| i.key_pressed(egui::Key::Delete) | i.key_pressed(egui::Key::Backspace)) {
-        state.interaction.selection.edges.iter().for_each(|e| {
-            state.graph.remove_edge(*e);
-        });
-        state.interaction.selection.nodes.clear();
     }
 }
 
@@ -371,19 +345,22 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
                 ui.label("Node spacing Y:");
                 ui.add(egui::Slider::new(&mut state.node_spacing[1], 0.5..=2.0));
             });
-            ui.horizontal(|ui| {
-                ui.label("Wire width:");
-                ui.add(egui::Slider::new(&mut state.wire_width, 0.5..=10.0));
-            });
-            ui.horizontal(|ui| {
-                ui.label("Socket radius:");
-                ui.add(egui::Slider::new(&mut state.socket_radius, 1.0..=10.0));
-            });
-            ui.horizontal(|ui| {
-                ui.label("Wire color:");
-                ui.color_edit_button_srgba(&mut state.wire_color);
-                ui.label("Socket color:");
-                ui.color_edit_button_srgba(&mut state.socket_color);
+            ui.checkbox(&mut state.custom_edge_style, "Custom Edge Style");
+            ui.add_enabled_ui(state.custom_edge_style, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Edge width:");
+                    ui.add(egui::Slider::new(&mut state.edge_width, 0.5..=10.0));
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Socket radius:");
+                    ui.add(egui::Slider::new(&mut state.socket_radius, 1.0..=10.0));
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Edge color:");
+                    ui.color_edit_button_srgba(&mut state.edge_color);
+                    ui.label("Socket color:");
+                    ui.color_edit_button_srgba(&mut state.socket_color);
+                });
             });
             ui.label(format!("Scene: {:?}", view.scene_rect));
         });

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -92,11 +92,13 @@ impl<'a> Edge<'a> {
             .selection_rect
             .map(|rect| bezier.intersects_rect(distance_per_point, rect))
             .unwrap_or(false);
+        let edge_in_progress = ectx.in_progress(ui).is_some();
 
         // If already selected and clicked with ctrl down, or a press happened
         // elsewhere and ctrl was *not* held, deselect.
         if *selected {
-            if (clicked && ui.input(|i| i.modifiers.ctrl))
+            if edge_in_progress
+                || (clicked && ui.input(|i| i.modifiers.ctrl))
                 || ui.input(|i| i.pointer.primary_pressed() && !i.modifiers.ctrl)
             {
                 *selected = false;
@@ -136,7 +138,7 @@ impl<'a> Edge<'a> {
         let pts: Vec<_> = bezier.flatten(distance_per_point).collect();
         let stroke = if *selected {
             ui.style().visuals.selection.stroke
-        } else if hovered {
+        } else if hovered && !edge_in_progress {
             ui.style().visuals.widgets.hovered.fg_stroke
         } else if under_selection_rect && ui.input(|i| i.modifiers.shift) {
             ui.style().visuals.widgets.hovered.fg_stroke
@@ -166,7 +168,7 @@ impl EdgeResponse {
         self.hovered
     }
 
-    /// The edge was selected while `Delete` or `Backspace` where pressed.
+    /// The edge was selected while `Delete` or `Backspace` were pressed.
     pub fn deleted(&self) -> bool {
         self.deleted
     }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,0 +1,162 @@
+use crate::{bezier, EdgesCtx};
+
+/// A simple bezier-curve Edge widget.
+///
+/// Handles interaction (selection, deselection, deletion) and painting the
+/// bezier curve.
+///
+/// Adopts styling from the following:
+///
+/// - Selected: `ui.visuals().selection.fg_stroke`.
+/// - Hovered: `ui.visuals().widgets.hovered.fg_stroke`.
+/// - Otherwise: `ui.visuals().widgets.noninteractive.fg_stroke`.
+pub struct Edge<'a> {
+    edge: ((egui::Id, OutputIx), (egui::Id, SocketIx)),
+    distance_per_point: f32,
+    selected: &'a mut bool,
+}
+
+/// A response returned from the [`Edge`] widget.
+///
+/// Similar to [`egui::Response`], however as there's no clear rectangular space
+/// allocated to the edge, we use a more minimal custom response.
+pub struct EdgeResponse {
+    changed: bool,
+    clicked: bool,
+    hovered: bool,
+    deleted: bool,
+}
+
+/// An index of a node's input or output socket.
+pub type SocketIx = usize;
+/// An index of a node's input socket.
+pub type InputIx = SocketIx;
+/// An index of a node's output socket.
+pub type OutputIx = SocketIx;
+
+impl<'a> Edge<'a> {
+    pub const DEFAULT_DISTANCE_PER_POINT: f32 = 5.0;
+
+    /// An edge from node `a`'s output socket to node `b`'s input socket.
+    pub fn new(a: (egui::Id, OutputIx), b: (egui::Id, InputIx), selected: &'a mut bool) -> Self {
+        Self {
+            edge: (a, b),
+            distance_per_point: Self::DEFAULT_DISTANCE_PER_POINT,
+            selected,
+        }
+    }
+
+    /// The distance-per-point used to render the bezier curve path.
+    ///
+    /// This path is also used to check for selection interaction.
+    ///
+    /// The smaller the distance, the higher-quality rendering and interactions
+    /// will be, at the cost of performance.
+    ///
+    /// Default: `Self::DEFAULT_DISTANCE_PER_POINT`
+    pub fn distance_per_point(mut self, dist: f32) -> Self {
+        self.distance_per_point = dist;
+        self
+    }
+
+    /// Process any user interaction with the edge and present it.
+    pub fn show(self, ectx: &mut EdgesCtx, ui: &mut egui::Ui) -> EdgeResponse {
+        let Self {
+            edge: ((a, output), (b, input)),
+            distance_per_point,
+            selected,
+        } = self;
+
+        // Retrieve the location and direction of the node sockets.
+        let a_out = ectx.output(ui, a, output).unwrap();
+        let b_in = ectx.input(ui, b, input).unwrap();
+
+        // TODO: Cache the curve and its points.
+        let bezier = bezier::Cubic::from_edge_points(a_out, b_in);
+
+        // Check the graph `Ui` for interaction.
+        let response = ui.response();
+        let mouse_pos = response
+            .interact_pointer_pos()
+            .or(response.hover_pos())
+            .unwrap_or_default();
+
+        // If the mouse was clicked on the `Ui`, check for edge interaction.
+        let closest_point = bezier.closest_point(distance_per_point, mouse_pos);
+        let dist_to_mouse = closest_point.distance(mouse_pos);
+        let select_dist = ui.style().interaction.interact_radius;
+        let hovered = dist_to_mouse < select_dist;
+        let clicked = hovered && response.clicked();
+        let old_selected = *selected;
+
+        // If already selected and clicked with ctrl down, or a press happened
+        // elsewhere and ctrl was *not* held, deselect.
+        if *selected {
+            if (clicked && ui.input(|i| i.modifiers.ctrl))
+                || ui.input(|i| i.pointer.primary_pressed() && !i.modifiers.ctrl)
+            {
+                *selected = false;
+            }
+        // Otherwise if clicked, select.
+        } else if clicked {
+            *selected = true;
+        }
+
+        // Check if the edge was deleted.
+        let mut deleted = false;
+        // FIXME: We may only want to do this if `ui.id()` has focus
+        // (Memory::has_focus) or similar, but we still need to setup proper
+        // focus-requesting and consider how to handle nodes too.
+        if *selected && !ui.ctx().wants_keyboard_input() {
+            let del_keys = [egui::Key::Delete, egui::Key::Backspace];
+            if ui.input(|i| del_keys.iter().any(|&k| i.key_pressed(k))) {
+                deleted = true;
+            }
+        }
+
+        // Construct the response.
+        let changed = old_selected != *selected;
+        let response = EdgeResponse {
+            changed,
+            clicked,
+            hovered,
+            deleted,
+        };
+
+        // Paint the edge.
+        let pts: Vec<_> = bezier.flatten(distance_per_point).collect();
+        let stroke = if *selected {
+            ui.style().visuals.selection.stroke
+        } else if hovered {
+            ui.style().visuals.widgets.hovered.fg_stroke
+        } else {
+            ui.style().visuals.widgets.noninteractive.fg_stroke
+        };
+        ui.painter().add(egui::Shape::line(pts, stroke));
+
+        // Return the response.
+        response
+    }
+}
+
+impl EdgeResponse {
+    /// Whether or not the edge selected state changed.
+    pub fn changed(&self) -> bool {
+        self.changed
+    }
+
+    /// The edge was clicked.
+    pub fn clicked(&self) -> bool {
+        self.clicked
+    }
+
+    /// The pointer hovers over the edge.
+    pub fn hovered(&self) -> bool {
+        self.hovered
+    }
+
+    /// The edge was selected while `Delete` or `Backspace` where pressed.
+    pub fn deleted(&self) -> bool {
+        self.deleted
+    }
+}

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -11,7 +11,7 @@ use crate::{bezier, EdgesCtx};
 /// - Hovered: `ui.visuals().widgets.hovered.fg_stroke`.
 /// - Otherwise: `ui.visuals().widgets.noninteractive.fg_stroke`.
 pub struct Edge<'a> {
-    edge: ((egui::Id, OutputIx), (egui::Id, SocketIx)),
+    edge: ((egui::Id, OutputIx), (egui::Id, InputIx)),
     distance_per_point: f32,
     selected: &'a mut bool,
 }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -85,14 +85,16 @@ impl<'a> Edge<'a> {
         let closest_point = bezier.closest_point(distance_per_point, mouse_pos);
         let dist_to_mouse = closest_point.distance(mouse_pos);
         let select_dist = ui.style().interaction.interact_radius;
-        let hovered = dist_to_mouse < select_dist;
+        let edge_in_progress = ectx.in_progress(ui).is_some();
+        let hovered = dist_to_mouse < select_dist
+            && !edge_in_progress
+            && ui.input(|i| !i.pointer.primary_down() || i.pointer.could_any_button_be_click());
         let clicked = hovered && response.clicked();
         let old_selected = *selected;
         let under_selection_rect = ectx
             .selection_rect
             .map(|rect| bezier.intersects_rect(distance_per_point, rect))
             .unwrap_or(false);
-        let edge_in_progress = ectx.in_progress(ui).is_some();
 
         // If already selected and clicked with ctrl down, or a press happened
         // elsewhere and ctrl was *not* held, deselect.
@@ -138,7 +140,7 @@ impl<'a> Edge<'a> {
         let pts: Vec<_> = bezier.flatten(distance_per_point).collect();
         let stroke = if *selected {
             ui.style().visuals.selection.stroke
-        } else if hovered && !edge_in_progress {
+        } else if hovered {
             ui.style().visuals.widgets.hovered.fg_stroke
         } else if under_selection_rect && ui.input(|i| i.modifiers.shift) {
             ui.style().visuals.widgets.hovered.fg_stroke

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 pub use layout::layout;
 
 pub mod bezier;
+pub mod edge;
 #[cfg(feature = "layout")]
 pub mod layout;
 pub mod node;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,6 +596,19 @@ impl EdgeInProgress {
         let end = (self.end_pos, end_normal);
         bezier::Cubic::from_edge_points(start, end)
     }
+
+    /// Short-hand for painting the in-progress edge with some reasonable defaults.
+    ///
+    /// If you require custom styling of the in-progress edge, use
+    /// [`EdgeInProgress::bezier_cubic`] or the individual fields to paint it
+    /// however you wish.
+    pub fn show(&self, ui: &egui::Ui) {
+        let dist_per_pt = crate::edge::Edge::DEFAULT_DISTANCE_PER_POINT;
+        let bezier = self.bezier_cubic();
+        let pts = bezier.flatten(dist_per_pt).collect();
+        let stroke = ui.visuals().widgets.active.fg_stroke;
+        ui.painter().add(egui::Shape::line(pts, stroke));
+    }
 }
 
 impl Default for View {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,7 +729,7 @@ fn graph_interaction(
         }
 
         // The press action has ended.
-        if pointer.any_released() && !pointer.button_down(egui::PointerButton::Primary) {
+        if pointer.primary_released() {
             match pressed.action {
                 PressAction::Select => select = true,
                 PressAction::Socket(socket) => socket_press_released = Some(socket),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,6 @@ type NodeSizes = HashMap<egui::Id, egui::Vec2>;
 struct Selection {
     /// The set of currently selected nodes.
     nodes: HashSet<egui::Id>,
-    /// The set of currently selected edges.
-    edges: HashSet<(node::Socket, node::Socket)>,
 }
 
 /// State related to the last press of the primary pointer button over the graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub struct Show<'a> {
     graph_id: egui::Id,
     /// The full area covered by the `Graph` within the UI.
     graph_rect: egui::Rect,
-    /// If a selection is being performed with the mouse, this is the covered area.
+    /// If a selection is being performed with the pointer, this is the covered area.
     selection_rect: Option<egui::Rect>,
     /// Whether or not the primary mouse button was just released to perform the selection.
     select: bool,
@@ -160,6 +160,7 @@ pub struct NodesCtx<'a> {
 pub struct EdgesCtx {
     graph_id: egui::Id,
     graph_rect: egui::Rect,
+    selection_rect: Option<egui::Rect>,
 }
 
 /// The set of detected graph interaction for a single graph widget update prior
@@ -453,11 +454,13 @@ impl<'a> Show<'a> {
             let Self {
                 graph_rect,
                 graph_id,
+                selection_rect,
                 ..
             } = self;
             let mut ctx = EdgesCtx {
                 graph_id,
                 graph_rect,
+                selection_rect,
             };
             content(&mut ctx, ui);
         }


### PR DESCRIPTION
Closes #30 
Closes #31 

The new `Edge` widget gets its styling from `ui.visuals().widgets` to better follow whatever the existing theme is. To customise the edge styling, users now need to make a scoped `Ui` with a temporary custom style. I've updated the demo to show how to do this.