### PR TITLE
fix: Ensure interpolation and node frame egui IDs are unique per Graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo:
+    permissions:
+      id-token: "write"
+      contents: "read"
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - command: check --locked --all
+          - command: doc --all-features --locked --no-deps
+          - command: fmt --all -- --check
+          - command: test --locked --all
+          - command: test --no-default-features --locked --all
+          - command: test --all-features --locked --all
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: Swatinem/rust-cache@v2
+      - run: nix develop github:mitchmindtree/egui.nix -c cargo ${{ matrix.command }}
+
+  cargo-publish:
+    needs: cargo
+    permissions:
+      id-token: "write"
+      contents: "read"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: nicknovitski/nix-develop@v1.2.1
+        with:
+          arguments: "github:mitchmindtree/egui.nix"
+      - uses: Swatinem/rust-cache@v2
+      - uses: katyo/publish-crates@v2
+        id: publish-crates
+        with:
+          registry-token: ${{ secrets.CRATESIO_TOKEN }}
+          dry-run: ${{ github.event_name != 'push' }}
+          ignore-unpublished-changes: true
+      - name: List published crates
+        if: ${{ steps.publish-crates.outputs.published != '' }}
+        run: |
+          LIST="${{ join(fromJSON(steps.publish-crates.outputs.published).*.name, ', ') }}"
+          echo "Published crates: $LIST"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/nannou-org/nannou.git"
 resolver = "2"
 
 [dependencies]
-egui = { version = "0.33", default-features = false, optional = true }
+egui = { version = "0.33", default-features = false }
 layout-rs = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -25,6 +25,7 @@ struct State {
     custom_edge_style: bool,
     edge_width: f32,
     edge_color: egui::Color32,
+    #[cfg(feature = "layout")]
     auto_layout: bool,
     node_spacing: [f32; 2],
     node_id_map: HashMap<egui::Id, NodeIndex>,
@@ -73,6 +74,7 @@ impl App {
             edge_width: 1.0,
             edge_color: ctx.style().visuals.weak_text_color(),
             flow: egui::Direction::TopDown,
+            #[cfg(feature = "layout")]
             auto_layout: true,
             node_spacing: [1.0, 1.0],
             node_id_map: Default::default(),
@@ -86,6 +88,7 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        #[cfg(feature = "layout")]
         if self.state.auto_layout {
             self.view.layout = layout(
                 &self.state.graph,
@@ -121,6 +124,7 @@ fn node(name: impl ToString, kind: NodeKind) -> Node {
     Node { name, kind }
 }
 
+#[cfg(feature = "layout")]
 fn layout(
     graph: &Graph,
     flow: egui::Direction,
@@ -320,6 +324,7 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
         .auto_sized()
         .show(ui.ctx(), |ui| {
             ui.label("GRAPH CONFIG");
+            #[cfg(feature = "layout")]
             ui.horizontal(|ui| {
                 ui.checkbox(&mut state.auto_layout, "Automatic Layout");
                 ui.separator();

--- a/src/node.rs
+++ b/src/node.rs
@@ -196,9 +196,9 @@ impl Node {
             self.animation_time
         };
         let pos_graph = {
+            let idx = ctx.graph_id.with(self.id).with("x");
+            let idy = ctx.graph_id.with(self.id).with("y");
             let ctx = ui.ctx();
-            let idx = self.id.with("x");
-            let idy = self.id.with("y");
             let x = ctx.animate_value_with_time(idx, target_pos_graph.x, animation_time);
             let y = ctx.animate_value_with_time(idy, target_pos_graph.y, animation_time);
             egui::Pos2::new(x, y)
@@ -293,7 +293,7 @@ impl Node {
 
         // Put the node's frame on a layer above the scene's UI layer.
         let scene_layer = ui.layer_id();
-        let frame_layer = egui::LayerId::new(scene_layer.order, self.id);
+        let frame_layer = egui::LayerId::new(scene_layer.order, ctx.graph_id.with(self.id));
         ui.ctx().set_sublayer(scene_layer, frame_layer);
         if let Some(transform) = ui.ctx().layer_transform_to_global(scene_layer) {
             ui.ctx().set_transform_layer(frame_layer, transform);


### PR DESCRIPTION
This fixes an issue where where there would be some node and interpolation conflicts if multiple graphs were shown at once.

Also adds a github CI workflow with a publish job.