### PR TITLE
feat: Introduce `NodeId` type decoupled from `egui::Id`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,4 +1,4 @@
-use crate::{bezier, EdgesCtx};
+use crate::{bezier, EdgesCtx, NodeId};
 
 /// A simple bezier-curve Edge widget.
 ///
@@ -11,7 +11,7 @@ use crate::{bezier, EdgesCtx};
 /// - Hovered: `ui.visuals().widgets.hovered.fg_stroke`.
 /// - Otherwise: `ui.visuals().widgets.noninteractive.fg_stroke`.
 pub struct Edge<'a> {
-    edge: ((egui::Id, OutputIx), (egui::Id, InputIx)),
+    edge: ((NodeId, OutputIx), (NodeId, InputIx)),
     distance_per_point: f32,
     selected: &'a mut bool,
 }
@@ -38,7 +38,7 @@ impl<'a> Edge<'a> {
     pub const DEFAULT_DISTANCE_PER_POINT: f32 = 5.0;
 
     /// An edge from node `a`'s output socket to node `b`'s input socket.
-    pub fn new(a: (egui::Id, OutputIx), b: (egui::Id, InputIx), selected: &'a mut bool) -> Self {
+    pub fn new(a: (NodeId, OutputIx), b: (NodeId, InputIx), selected: &'a mut bool) -> Self {
         Self {
             edge: (a, b),
             distance_per_point: Self::DEFAULT_DISTANCE_PER_POINT,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,6 @@
 //! Items related to automated layout of nodes.
 
-use crate::Layout;
+use crate::{Layout, NodeId};
 use egui::Direction;
 use layout::{
     core::{base::Orientation, geometry::Point, style::*},
@@ -13,8 +13,8 @@ use std::collections::HashMap;
 ///
 /// Returns a `Layout` object representing the positions of nodes in the graph.
 pub fn layout(
-    nodes: impl IntoIterator<Item = (egui::Id, egui::Vec2)>,
-    edges: impl IntoIterator<Item = (egui::Id, egui::Id)>,
+    nodes: impl IntoIterator<Item = (NodeId, egui::Vec2)>,
+    edges: impl IntoIterator<Item = (NodeId, NodeId)>,
     flow: egui::Direction,
 ) -> Layout {
     let orientation = match flow {


### PR DESCRIPTION
Add a dedicated `NodeId` type for identifying nodes within a graph, separate from egui's internal `Id` type. This allows node identity and layout positions to remain stable even when the graph widget's egui ID context changes (e.g., when viewing the same graph through different UI paths or contexts).

Key changes:
- Add `NodeId` wrapper type around `u64` with constructors
- Change `Layout` from `HashMap<egui::Id, Pos2>` to `HashMap<NodeId, Pos2>`
- Update `Node::from_id` to accept `NodeId` instead of `egui::Id`
- Update `Edge` to use `NodeId` for node references
- Add `node::egui_id(graph_id, node_id)` helper to derive internal
  egui::Id for area_rect lookups
- Update selection tracking to use `NodeId`
- Update `layout()` function signature to use `NodeId`

**BREAKING CHANGE:** Public API now uses `NodeId` instead of `egui::Id` for node identification. Users must update their code to use `NodeId::new()`, `NodeId::from_u64()`, or `NodeId::from()`.