### PR TITLE
feat: Add graph memory access API, use correct `node_sizes` for node layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -137,34 +137,38 @@ fn layout(
     ctx: &egui::Context,
 ) -> egui_graph::Layout {
     let graph_id = graph_id();
-    ctx.memory(|m| {
-        let nodes = graph.node_indices().map(|n| {
-            let node_id = egui_graph::NodeId::from_u64(n.index() as u64);
-            // Use the helper to get the egui::Id for area_rect lookup
-            let egui_id = egui_graph::node::egui_id(graph_id, node_id);
-            let size = m
-                .area_rect(egui_id)
-                .map(|a| a.size())
-                .unwrap_or([200.0, 50.0].into());
-            (node_id, size)
+    // Access graph memory once and iterate inside to avoid repeated locks
+    let nodes_vec = egui_graph::with_graph_memory(ctx, graph_id, |gmem| {
+        let node_sizes = gmem.node_sizes();
+        graph
+            .node_indices()
+            .map(|n| {
+                let node_id = egui_graph::NodeId::from_u64(n.index() as u64);
+                let size = node_sizes
+                    .get(&node_id)
+                    .cloned()
+                    .unwrap_or_else(|| [200.0, 50.0].into());
+                (node_id, size)
+            })
+            .collect::<Vec<_>>()
+    });
+    let nodes = nodes_vec.into_iter();
+    let edges = graph
+        .edge_indices()
+        .filter_map(|e| graph.edge_endpoints(e))
+        .map(|(a, b)| {
+            (
+                egui_graph::NodeId::from_u64(a.index() as u64),
+                egui_graph::NodeId::from_u64(b.index() as u64),
+            )
         });
-        let edges = graph
-            .edge_indices()
-            .filter_map(|e| graph.edge_endpoints(e))
-            .map(|(a, b)| {
-                (
-                    egui_graph::NodeId::from_u64(a.index() as u64),
-                    egui_graph::NodeId::from_u64(b.index() as u64),
-                )
-            });
-        let mut layout = egui_graph::layout(nodes, edges, flow);
-        // Apply custom offset spacing to the layout
-        for pos in layout.values_mut() {
-            pos.x *= node_spacing[0];
-            pos.y *= node_spacing[1];
-        }
-        layout
-    })
+    let mut layout = egui_graph::layout(nodes, edges, flow);
+    // Apply custom offset spacing to the layout
+    for pos in layout.values_mut() {
+        pos.x *= node_spacing[0];
+        pos.y *= node_spacing[1];
+    }
+    layout
 }
 
 fn gui(ctx: &egui::Context, view: &mut egui_graph::View, state: &mut State) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,13 @@ impl Graph {
     }
 }
 
+impl GraphTempMemory {
+    /// Get the recorded sizes of all nodes.
+    pub fn node_sizes(&self) -> &NodeSizes {
+        &self.node_sizes
+    }
+}
+
 impl NodeSockets {
     /// The screen position and normal of the input at the given index.
     ///
@@ -845,6 +852,23 @@ fn paint_selection_area(sel_rect: egui::Rect, ui: &mut egui::Ui) {
 /// Combines the given id src with the `TypeId` of the `Graph` to produce a unique `egui::Id`.
 pub fn id(id_src: impl Hash) -> egui::Id {
     egui::Id::new((std::any::TypeId::of::<Graph>(), id_src))
+}
+
+/// Access the graph's temporary memory for the given graph ID.
+///
+/// This allows reading graph state like node sizes without cloning.
+/// If no memory exists for the graph ID, a default GraphTempMemory is created and stored.
+pub fn with_graph_memory<R>(
+    ctx: &egui::Context,
+    graph_id: egui::Id,
+    f: impl FnOnce(&GraphTempMemory) -> R,
+) -> R {
+    let gmem_arc = ctx.data_mut(|d| {
+        d.get_temp_mut_or_default::<Arc<Mutex<GraphTempMemory>>>(graph_id)
+            .clone()
+    });
+    let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
+    f(&*gmem)
 }
 
 /// Checks if a node with the given ID is currently selected in the specified graph.


### PR DESCRIPTION
Expose `node_sizes()` method on `GraphTempMemory` and add `with_graph_memory()` function for efficient access to graph state. The function provides a closure-based API that avoids cloning data and automatically creates default memory if none exists.

We now use the new API to correctly retrieve node sizes during layout in the demo. Previously we attempted to use `area_rect`, however it turns out this is only generated for `Area` widgets in egui, and so for the nodes it always returned `None`, resulting in the fallback node size for layout.