### PR TITLE
feat!: return `GraphResponse` from `Graph::show()` with post-frame selection snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -181,7 +181,7 @@ fn gui(ctx: &egui::Context, view: &mut egui_graph::View, state: &mut State) {
 }
 
 fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
-    egui_graph::Graph::from_id(graph_id())
+    let graph_response = egui_graph::Graph::from_id(graph_id())
         .center_view(state.center_view)
         .dot_grid(state.dot_grid)
         .show(view, ui, |ui, show| {
@@ -193,6 +193,13 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
                     edges(ectx, ui, state)
                 });
         });
+
+    // Sync the demo's selection state from the authoritative post-frame snapshot.
+    state.interaction.selection.nodes = graph_response
+        .selected_nodes
+        .iter()
+        .filter_map(|node_id| state.node_id_map.get(node_id).copied())
+        .collect();
 }
 
 fn set_edge_style(style: &mut egui::Style, state: &mut State) {
@@ -254,13 +261,6 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
             });
 
         if response.changed() {
-            // Update the selected nodes.
-            if egui_graph::is_node_selected(ui, nctx.graph_id, node_id) {
-                state.interaction.selection.nodes.insert(n);
-            } else {
-                state.interaction.selection.nodes.remove(&n);
-            }
-
             // Check for an edge event.
             if let Some(ev) = response.edge_event() {
                 match ev {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -194,12 +194,13 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
                 });
         });
 
-    // Sync the demo's selection state from the authoritative post-frame snapshot.
-    state.interaction.selection.nodes = graph_response
-        .selected_nodes
-        .iter()
-        .filter_map(|node_id| state.node_id_map.get(node_id).copied())
-        .collect();
+    // Sync the demo's selection state when it changes.
+    if let Some(selected) = graph_response.selection_changed {
+        state.interaction.selection.nodes = selected
+            .iter()
+            .filter_map(|node_id| state.node_id_map.get(node_id).copied())
+            .collect();
+    }
 }
 
 fn set_edge_style(style: &mut egui::Style, state: &mut State) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ type NodeSizes = HashMap<NodeId, egui::Vec2>;
 struct Selection {
     /// The set of currently selected nodes.
     nodes: HashSet<NodeId>,
+    /// Whether the selection was modified this frame.
+    changed: bool,
 }
 
 /// State related to the last press of the primary pointer button over the graph.
@@ -186,6 +188,8 @@ pub struct GraphResponse<R> {
     pub response: egui::Response,
     /// The set of selected nodes after this frame.
     pub selected_nodes: HashSet<NodeId>,
+    /// Whether the node selection changed this frame.
+    pub selection_changed: bool,
 }
 
 impl Graph {
@@ -312,6 +316,9 @@ impl Graph {
                 gmem.selection.nodes = nodes;
             }
 
+            // Reset the selection dirty flag for this frame.
+            gmem.selection.changed = false;
+
             // FIXME: Here we grab the global pointer and transform its position
             // to the graph scene space in order to check for initialising node
             // drag events. However, doing this means we run the risk of
@@ -404,8 +411,9 @@ impl Graph {
             let gmem_arc = memory(ui, self.id);
             let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
             let selected_nodes = gmem.selection.nodes.clone();
+            let selection_changed = gmem.selection.changed;
 
-            (output, selected_nodes)
+            (output, selected_nodes, selection_changed)
         });
 
         if self.center_view {
@@ -414,11 +422,12 @@ impl Graph {
             }
         }
 
-        let (inner, selected_nodes) = scene_response.inner;
+        let (inner, selected_nodes, selection_changed) = scene_response.inner;
         GraphResponse {
             inner,
             response: scene_response.response,
             selected_nodes,
+            selection_changed,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,16 @@ struct GraphInteraction {
     drag_nodes_delta: egui::Vec2,
 }
 
+/// The response returned by [`Graph::show`].
+pub struct GraphResponse<R> {
+    /// The user's return value from the content closure.
+    pub inner: R,
+    /// The egui [`Response`][egui::Response] for the graph's scene area.
+    pub response: egui::Response,
+    /// The set of selected nodes after this frame.
+    pub selected_nodes: HashSet<NodeId>,
+}
+
 impl Graph {
     /// The default zoom range.
     ///
@@ -255,13 +265,14 @@ impl Graph {
 
     /// Begin showing the Graph.
     ///
-    /// Returns the `InnerResponse` of the inner `Scene`.
+    /// Returns a [`GraphResponse`] containing the user's return value,
+    /// the scene [`egui::Response`], and the current set of selected nodes.
     pub fn show<R>(
         mut self,
         view: &mut View,
         ui: &mut egui::Ui,
         content: impl FnOnce(&mut egui::Ui, Show) -> R,
-    ) -> egui::response::InnerResponse<R> {
+    ) -> GraphResponse<R> {
         // The full area to be occuppied by the graph.
         let graph_rect = ui.available_rect_before_wrap();
 
@@ -389,7 +400,12 @@ impl Graph {
             prune_unused_nodes(self.id, &visited, ui);
             bounding_rect = Some(ui.min_rect());
 
-            output
+            // Snapshot selection after all node processing.
+            let gmem_arc = memory(ui, self.id);
+            let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
+            let selected_nodes = gmem.selection.nodes.clone();
+
+            (output, selected_nodes)
         });
 
         if self.center_view {
@@ -398,7 +414,12 @@ impl Graph {
             }
         }
 
-        scene_response
+        let (inner, selected_nodes) = scene_response.inner;
+        GraphResponse {
+            inner,
+            response: scene_response.response,
+            selected_nodes,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,8 @@ pub struct GraphResponse<R> {
     pub inner: R,
     /// The egui [`Response`][egui::Response] for the graph's scene area.
     pub response: egui::Response,
-    /// The set of selected nodes after this frame.
-    pub selected_nodes: HashSet<NodeId>,
-    /// Whether the node selection changed this frame.
-    pub selection_changed: bool,
+    /// The set of selected nodes, present only when the selection changed this frame.
+    pub selection_changed: Option<HashSet<NodeId>>,
 }
 
 impl Graph {
@@ -407,13 +405,16 @@ impl Graph {
             prune_unused_nodes(self.id, &visited, ui);
             bounding_rect = Some(ui.min_rect());
 
-            // Snapshot selection after all node processing.
+            // Snapshot selection only if it changed this frame.
             let gmem_arc = memory(ui, self.id);
             let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
-            let selected_nodes = gmem.selection.nodes.clone();
-            let selection_changed = gmem.selection.changed;
+            let selection_changed = if gmem.selection.changed {
+                Some(gmem.selection.nodes.clone())
+            } else {
+                None
+            };
 
-            (output, selected_nodes, selection_changed)
+            (output, selection_changed)
         });
 
         if self.center_view {
@@ -422,11 +423,10 @@ impl Graph {
             }
         }
 
-        let (inner, selected_nodes, selection_changed) = scene_response.inner;
+        let (inner, selection_changed) = scene_response.inner;
         GraphResponse {
             inner,
             response: scene_response.response,
-            selected_nodes,
             selection_changed,
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -299,13 +299,9 @@ impl Node {
             // Update the selection if the primary mouse button was just released.
             if ctx.select {
                 if in_selection_rect && ui.input(|i| !i.modifiers.shift) {
-                    if gmem.selection.nodes.insert(self.id) {
-                        selection_changed = true;
-                    }
+                    selection_changed |= gmem.selection.nodes.insert(self.id);
                 } else if !ui.input(|i| i.modifiers.ctrl) {
-                    if gmem.selection.nodes.remove(&self.id) {
-                        selection_changed = true;
-                    }
+                    selection_changed |= gmem.selection.nodes.remove(&self.id);
                 }
             }
 
@@ -376,14 +372,15 @@ impl Node {
                 // If ctrl is down, check for deselection.
                 let was_selected = gmem.selection.nodes.contains(&self.id);
                 if ctrl_down && was_selected {
-                    selection_changed = gmem.selection.nodes.remove(&self.id);
+                    selection_changed |= gmem.selection.nodes.remove(&self.id);
                     selected = false;
                 } else {
                     // Clear other selections if ctrl is not pressed and this is newly pressed.
                     if !ctrl_down && !was_selected {
+                        gmem.selection.changed |= !gmem.selection.nodes.is_empty();
                         gmem.selection.nodes.clear();
                     }
-                    selection_changed = gmem.selection.nodes.insert(self.id);
+                    selection_changed |= gmem.selection.nodes.insert(self.id);
                     selected = true;
                     // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
                     if gmem.pressed.is_none() {
@@ -424,7 +421,7 @@ impl Node {
                         .unwrap_or(false)
                     && !gmem.selection.nodes.contains(&self.id)
                 {
-                    selection_changed = gmem.selection.nodes.remove(&self.id);
+                    selection_changed |= gmem.selection.nodes.remove(&self.id);
                     selected = false;
                 }
 
@@ -587,12 +584,19 @@ impl Node {
             // Remove ourselves from the selection.
             let gmem_arc = crate::memory(ui, ctx.graph_id);
             let mut gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
-            selection_changed = gmem.selection.nodes.remove(&self.id);
+            selection_changed |= gmem.selection.nodes.remove(&self.id);
             selected = false;
             true
         } else {
             false
         };
+
+        // Propagate this node's selection change to the graph-level dirty flag.
+        if selection_changed {
+            let gmem_arc = crate::memory(ui, ctx.graph_id);
+            let mut gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
+            gmem.selection.changed = true;
+        }
 
         if selection_changed || removed || edge_event.is_some() {
             response.mark_changed();


### PR DESCRIPTION
Selection is a graph-level concern mutated during sequential per-node processing, so individual `NodeResponse::changed()` cannot reliably report deselection of other nodes.

`GraphResponse::selection_changed` now provides a post-frame snapshot of the currently selected nodes in the case that the selection has changed.

BREAKING CHANGE: `Graph::show()` returns `GraphResponse<R>` instead of `egui::response::InnerResponse<R>`.

Closes #47.