### PR TITLE
feat: add immutable mode for view-only graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -31,6 +31,7 @@ struct State {
     node_id_map: HashMap<egui_graph::NodeId, NodeIndex>,
     center_view: bool,
     dot_grid: bool,
+    immutable: bool,
 }
 
 #[derive(Default)]
@@ -80,6 +81,7 @@ impl App {
             node_id_map: Default::default(),
             center_view: false,
             dot_grid: true,
+            immutable: false,
         };
         let view = Default::default();
         App { view, state }
@@ -184,6 +186,7 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
     let graph_response = egui_graph::Graph::from_id(graph_id())
         .center_view(state.center_view)
         .dot_grid(state.dot_grid)
+        .immutable(state.immutable)
         .show(view, ui, |ui, show| {
             show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
                 .edges(ui, |ectx, ui| {
@@ -357,6 +360,7 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
             });
             ui.checkbox(&mut state.dot_grid, "Show Dot Grid");
             ui.checkbox(&mut state.center_view, "Center View");
+            ui.checkbox(&mut state.immutable, "Immutable");
             ui.horizontal(|ui| {
                 ui.label("Flow:");
                 ui.radio_value(&mut state.flow, egui::Direction::LeftToRight, "Right");

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -123,12 +123,12 @@ impl<'a> Edge<'a> {
             *selected = true;
         }
 
-        // Check if the edge was deleted.
+        // Check if the edge was deleted (skip when immutable).
         let mut deleted = false;
         // FIXME: We may only want to do this if `ui.id()` has focus
         // (Memory::has_focus) or similar, but we still need to setup proper
         // focus-requesting and consider how to handle nodes too.
-        if *selected && !ui.ctx().wants_keyboard_input() {
+        if !ectx.immutable && *selected && !ui.ctx().wants_keyboard_input() {
             let del_keys = [egui::Key::Delete, egui::Key::Backspace];
             if ui.input(|i| del_keys.iter().any(|&k| i.key_pressed(k))) {
                 deleted = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,14 @@ pub struct Graph {
     id: egui::Id,
     /// If set, overwrite the graph's selected nodes at the start of the frame.
     selected_nodes: Option<HashSet<NodeId>>,
+    /// When `true`, prevents structural changes while preserving navigation and
+    /// selection.
+    ///
+    /// Unlike `Ui::set_enabled(false)` which disables all interaction
+    /// (including panning, zooming, and selection), `immutable` only prevents
+    /// structural changes - node positions, edges, and node content remain
+    /// view-only while navigation and selection continue to work.
+    immutable: bool,
 }
 
 /// State related to the graph UI.
@@ -133,6 +141,8 @@ pub struct Show<'a> {
     /// We will use this to remove old node state on `drop`.
     visited: &'a mut HashSet<NodeId>,
     layout: &'a mut Layout,
+    /// Whether the graph is in immutable (view-only) mode.
+    immutable: bool,
 }
 
 /// Information about the inputs and outputs for a particular node.
@@ -160,6 +170,8 @@ pub struct NodesCtx<'a> {
     socket_press_released: Option<node::Socket>,
     visited: &'a mut HashSet<NodeId>,
     layout: &'a mut Layout,
+    /// Whether the graph is in immutable (view-only) mode.
+    pub immutable: bool,
 }
 
 /// A context to assist with the instantiation of edge widgets.
@@ -168,6 +180,8 @@ pub struct EdgesCtx {
     graph_rect: egui::Rect,
     selection_rect: Option<egui::Rect>,
     closest_socket: Option<node::Socket>,
+    /// Whether the graph is in immutable (view-only) mode.
+    pub immutable: bool,
 }
 
 /// The set of detected graph interaction for a single graph widget update prior
@@ -216,6 +230,7 @@ impl Graph {
             center_view: Self::DEFAULT_CENTER_VIEW,
             id,
             selected_nodes: None,
+            immutable: false,
         }
     }
 
@@ -262,6 +277,18 @@ impl Graph {
     /// at the start of the next `show` call.
     pub fn selected_nodes(mut self, nodes: HashSet<NodeId>) -> Self {
         self.selected_nodes = Some(nodes);
+        self
+    }
+
+    /// Set immutable (view-only) mode.
+    ///
+    /// When `true`, prevents structural changes while preserving navigation
+    /// and selection. Node dragging, edge creation/deletion, node deletion,
+    /// and node content widgets are all disabled.
+    ///
+    /// Default: `false`.
+    pub fn immutable(mut self, immutable: bool) -> Self {
+        self.immutable = immutable;
         self
     }
 
@@ -337,18 +364,22 @@ impl Graph {
                     find_closest_socket(pos, layout, &gmem, ui).map(|(socket, _dist_sqrd)| socket)
                 });
 
+                // When immutable, suppress socket presses (map to Select).
+                let closest_socket_for_interaction =
+                    if self.immutable { None } else { closest_socket };
+
                 // Check for graph interactions.
                 let interaction = graph_interaction(
                     layout,
                     &pointer,
-                    closest_socket,
+                    closest_socket_for_interaction,
                     ptr_on_graph,
                     ptr_graph,
                     gmem.pressed.as_ref(),
                 );
 
-                // Apply drag delta to all selected nodes.
-                if interaction.drag_nodes_delta != egui::Vec2::ZERO {
+                // Apply drag delta to all selected nodes (skip when immutable).
+                if !self.immutable && interaction.drag_nodes_delta != egui::Vec2::ZERO {
                     if let Some(pressed) = gmem.pressed.as_ref() {
                         if let PressAction::DragNodes { .. } = pressed.action {
                             for &n_id in &gmem.selection.nodes {
@@ -395,6 +426,7 @@ impl Graph {
                 socket_press_released,
                 visited: &mut visited,
                 layout,
+                immutable: self.immutable,
             };
 
             // Drop the lock before running the content.
@@ -501,6 +533,7 @@ impl<'a> Show<'a> {
                 socket_press_released,
                 ref mut visited,
                 ref mut layout,
+                immutable,
                 ..
             } = self;
             let mut ctx = NodesCtx {
@@ -511,6 +544,7 @@ impl<'a> Show<'a> {
                 socket_press_released,
                 visited: &mut *visited,
                 layout: &mut *layout,
+                immutable,
             };
             content(&mut ctx, ui);
         }
@@ -529,6 +563,7 @@ impl<'a> Show<'a> {
                 graph_id,
                 selection_rect,
                 closest_socket,
+                immutable,
                 ..
             } = self;
             let mut ctx = EdgesCtx {
@@ -536,6 +571,7 @@ impl<'a> Show<'a> {
                 graph_rect,
                 selection_rect,
                 closest_socket,
+                immutable,
             };
             content(&mut ctx, ui);
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -103,6 +103,7 @@ pub struct NodeCtx<'a> {
     min_size: egui::Vec2,
     graph_id: egui::Id,
     node_id: NodeId,
+    immutable: bool,
 }
 
 impl Node {
@@ -333,6 +334,7 @@ impl Node {
             .max_rect(put_rect)
             .layer_id(frame_layer)
             .sense(egui::Sense::click_and_drag());
+        let immutable = ctx.immutable;
         let inner_response = ui.scope_builder(builder, |ui| {
             let hovered = ui.response().hovered();
             // Create the NodeCtx and call the user's content closure.
@@ -348,6 +350,7 @@ impl Node {
                 min_size: content_min_size,
                 graph_id: ctx.graph_id,
                 node_id,
+                immutable,
             };
             content(node_ctx)
         });
@@ -382,8 +385,8 @@ impl Node {
                     }
                     selection_changed |= gmem.selection.nodes.insert(self.id);
                     selected = true;
-                    // We must initialize gmem.pressed here so that subsequent drag updates work correctly.
-                    if gmem.pressed.is_none() {
+                    // Initialize drag - skip when immutable (still allow click-to-select above).
+                    if !immutable && gmem.pressed.is_none() {
                         let ptr_graph = response.hover_pos().unwrap_or_default();
                         gmem.pressed = Some(crate::Pressed {
                             over_selection_at_origin: true,
@@ -399,8 +402,11 @@ impl Node {
                     }
                 }
 
-            // If the primary button was pressed, check for edge events.
-            } else if !response.is_pointer_button_down_on() && pointer.primary_pressed() {
+            // If the primary button was pressed, check for edge events (skip when immutable).
+            } else if !immutable
+                && !response.is_pointer_button_down_on()
+                && pointer.primary_pressed()
+            {
                 // If this node's socket was pressed, create a start event.
                 if let Some(ref pressed) = gmem.pressed {
                     if let crate::PressAction::Socket(socket) = pressed.action {
@@ -425,19 +431,21 @@ impl Node {
                     selected = false;
                 }
 
-            // Check for edge creation / cancellation events.
-            } else if let Some(r) = ctx.socket_press_released {
-                if let Some(c) = gmem.closest_socket {
-                    if r.kind == c.kind && self.id == r.node {
-                        edge_event = Some(EdgeEvent::Cancelled);
-                    } else if self.id == c.node && ui.input(|i| i.pointer.primary_released()) {
-                        let kind = c.kind;
-                        let index = c.index;
-                        edge_event = Some(EdgeEvent::Ended { kind, index });
-                    }
-                } else if edge_event.is_none() {
-                    if self.id == r.node {
-                        edge_event = Some(EdgeEvent::Cancelled);
+            // Check for edge creation / cancellation events (skip when immutable).
+            } else if !immutable {
+                if let Some(r) = ctx.socket_press_released {
+                    if let Some(c) = gmem.closest_socket {
+                        if r.kind == c.kind && self.id == r.node {
+                            edge_event = Some(EdgeEvent::Cancelled);
+                        } else if self.id == c.node && ui.input(|i| i.pointer.primary_released()) {
+                            let kind = c.kind;
+                            let index = c.index;
+                            edge_event = Some(EdgeEvent::Ended { kind, index });
+                        }
+                    } else if edge_event.is_none() {
+                        if self.id == r.node {
+                            edge_event = Some(EdgeEvent::Cancelled);
+                        }
                     }
                 }
             }
@@ -577,7 +585,9 @@ impl Node {
         }
 
         // If the delete or backspace key was pressed and the node is selected, remove it.
-        let removed = if selected
+        // Skip when immutable.
+        let removed = if !immutable
+            && selected
             && !ui.ctx().wants_keyboard_input()
             && ui.input(|i| i.key_pressed(egui::Key::Delete) | i.key_pressed(egui::Key::Backspace))
         {
@@ -753,10 +763,16 @@ impl<'a> NodeCtx<'a> {
         content: impl FnOnce(&mut egui::Ui) -> T,
     ) -> egui::InnerResponse<T> {
         let min_size = self.min_size;
+        let immutable = self.immutable;
         let builder = egui::UiBuilder::new().sense(egui::Sense::click_and_drag());
         let inner_response = frame.show(self.ui, |ui| {
             ui.scope_builder(builder, |ui| {
                 ui.set_min_size(min_size);
+                // Disable content widgets when immutable (inside the frame
+                // so that the frame itself retains normal styling).
+                if immutable {
+                    ui.disable();
+                }
                 content(ui)
             })
         });


### PR DESCRIPTION
Add `Graph::immutable(bool)` builder method that prevents structural
changes while preserving panning, zooming, and selection.

When enabled:
- Node dragging is disabled.
- Edge creation/deletion is suppressed.
- Node deletion via delete/backspace is skipped.
- Node content widgets are disabled (inside the frame, preserving frame styling).
- Socket presses are mapped to selection instead.

The demo example includes an "Immutable" checkbox to showcase the feature.