### PR TITLE
Add SocketLayout for explicit socket positioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -59,8 +59,8 @@ enum NodeKind {
     Slider(f32),
     DragValue(f32),
     Comment(String),
-    /// A table-style node with row-aligned sockets (Blender-style).
-    Table {
+    /// A mixer-style node with content-aligned sockets.
+    Mixer {
         color: f32,
         alpha: f32,
     },
@@ -120,7 +120,7 @@ fn new_graph() -> Graph {
     let e = graph.add_node(node("Fiz", NodeKind::Comment(comment.to_string())));
     let f = graph.add_node(node(
         "Mix",
-        NodeKind::Table {
+        NodeKind::Mixer {
             color: 0.5,
             alpha: 1.0,
         },
@@ -245,16 +245,10 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
         let node = &mut state.graph[n];
         let node_id = egui_graph::NodeId::from_u64(n.index() as u64);
         state.node_id_map.insert(node_id, n);
-        let is_table = matches!(node.kind, NodeKind::Table { .. });
-        let flow = if is_table {
-            egui::Direction::LeftToRight
-        } else {
-            state.flow
-        };
         let response = egui_graph::node::Node::from_id(node_id)
             .inputs(inputs)
             .outputs(outputs)
-            .flow(flow)
+            .flow(state.flow)
             .socket_radius(state.socket_radius)
             .socket_color(state.socket_color)
             .show(nctx, ui, |node_ctx| {
@@ -280,24 +274,43 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
                     NodeKind::Comment(ref mut text) => {
                         ui.text_edit_multiline(text);
                     }
-                    NodeKind::Table {
+                    NodeKind::Mixer {
                         ref mut color,
                         ref mut alpha,
-                    } => {
-                        ui.label(&node.name);
-                        sockets.row(ui, Some(0), Some(0), |ui| {
-                            ui.horizontal(|ui| {
-                                ui.label("Color");
-                                ui.add(egui::Slider::new(color, 0.0..=1.0));
+                    } => match state.flow {
+                        egui::Direction::LeftToRight | egui::Direction::RightToLeft => {
+                            sockets.row(ui, Some(0), None, |ui| {
+                                ui.horizontal(|ui| {
+                                    ui.label("Color");
+                                    ui.add(egui::Slider::new(color, 0.0..=1.0));
+                                });
                             });
-                        });
-                        sockets.row(ui, Some(1), None, |ui| {
-                            ui.horizontal(|ui| {
-                                ui.label("Alpha");
-                                ui.add(egui::Slider::new(alpha, 0.0..=1.0));
+                            sockets.row(ui, Some(1), Some(0), |ui| {
+                                ui.horizontal(|ui| {
+                                    ui.label("Alpha");
+                                    ui.add(egui::Slider::new(alpha, 0.0..=1.0));
+                                });
                             });
-                        });
-                    }
+                        }
+                        egui::Direction::TopDown | egui::Direction::BottomUp => {
+                            ui.horizontal(|ui| {
+                                sockets.col(ui, Some(0), None, |ui| {
+                                    ui.add(
+                                        egui::Slider::new(color, 0.0..=1.0)
+                                            .vertical()
+                                            .show_value(false),
+                                    );
+                                });
+                                sockets.col(ui, Some(1), Some(0), |ui| {
+                                    ui.add(
+                                        egui::Slider::new(alpha, 0.0..=1.0)
+                                            .vertical()
+                                            .show_value(false),
+                                    );
+                                });
+                            });
+                        }
+                    },
                 })
             });
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -277,22 +277,19 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
                     NodeKind::Mixer {
                         ref mut color,
                         ref mut alpha,
-                    } => match state.flow {
-                        egui::Direction::LeftToRight | egui::Direction::RightToLeft => {
-                            sockets.row(ui, Some(0), None, |ui| {
-                                ui.horizontal(|ui| {
+                    } => {
+                        if state.flow.is_horizontal() {
+                            sockets.grid(egui::Grid::new("mixer"), ui, |grid, ui| {
+                                grid.row(ui, Some(0), None, |ui| {
                                     ui.label("Color");
                                     ui.add(egui::Slider::new(color, 0.0..=1.0));
                                 });
-                            });
-                            sockets.row(ui, Some(1), Some(0), |ui| {
-                                ui.horizontal(|ui| {
+                                grid.row(ui, Some(1), Some(0), |ui| {
                                     ui.label("Alpha");
                                     ui.add(egui::Slider::new(alpha, 0.0..=1.0));
                                 });
                             });
-                        }
-                        egui::Direction::TopDown | egui::Direction::BottomUp => {
+                        } else if state.flow.is_vertical() {
                             ui.horizontal(|ui| {
                                 sockets.col(ui, Some(0), None, |ui| {
                                     ui.add(
@@ -310,7 +307,7 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
                                 });
                             });
                         }
-                    },
+                    }
                 })
             });
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -59,6 +59,11 @@ enum NodeKind {
     Slider(f32),
     DragValue(f32),
     Comment(String),
+    /// A table-style node with row-aligned sockets (Blender-style).
+    Table {
+        color: f32,
+        alpha: f32,
+    },
 }
 
 impl App {
@@ -113,11 +118,19 @@ fn new_graph() -> Graph {
     let comment = "Nodes are a thin wrapper around the `egui::Window`, \
         allowing you to set arbitrary widgets.";
     let e = graph.add_node(node("Fiz", NodeKind::Comment(comment.to_string())));
+    let f = graph.add_node(node(
+        "Mix",
+        NodeKind::Table {
+            color: 0.5,
+            alpha: 1.0,
+        },
+    ));
     graph.add_edge(a, c, (0, 0));
     graph.add_edge(a, d, (1, 1));
     graph.add_edge(b, d, (0, 2));
     graph.add_edge(c, d, (0, 0));
     graph.add_edge(d, e, (0, 0));
+    graph.add_edge(d, f, (0, 0));
     graph
 }
 
@@ -232,14 +245,20 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
         let node = &mut state.graph[n];
         let node_id = egui_graph::NodeId::from_u64(n.index() as u64);
         state.node_id_map.insert(node_id, n);
+        let is_table = matches!(node.kind, NodeKind::Table { .. });
+        let flow = if is_table {
+            egui::Direction::LeftToRight
+        } else {
+            state.flow
+        };
         let response = egui_graph::node::Node::from_id(node_id)
             .inputs(inputs)
             .outputs(outputs)
-            .flow(state.flow)
+            .flow(flow)
             .socket_radius(state.socket_radius)
             .socket_color(state.socket_color)
             .show(nctx, ui, |node_ctx| {
-                node_ctx.framed(|ui| match node.kind {
+                node_ctx.framed(|ui, sockets| match node.kind {
                     NodeKind::Label => {
                         ui.label(&node.name);
                     }
@@ -260,6 +279,24 @@ fn nodes(nctx: &mut egui_graph::NodesCtx, ui: &mut egui::Ui, state: &mut State) 
                     }
                     NodeKind::Comment(ref mut text) => {
                         ui.text_edit_multiline(text);
+                    }
+                    NodeKind::Table {
+                        ref mut color,
+                        ref mut alpha,
+                    } => {
+                        ui.label(&node.name);
+                        sockets.row(ui, Some(0), Some(0), |ui| {
+                            ui.horizontal(|ui| {
+                                ui.label("Color");
+                                ui.add(egui::Slider::new(color, 0.0..=1.0));
+                            });
+                        });
+                        sockets.row(ui, Some(1), None, |ui| {
+                            ui.horizontal(|ui| {
+                                ui.label("Alpha");
+                                ui.add(egui::Slider::new(alpha, 0.0..=1.0));
+                            });
+                        });
                     }
                 })
             });

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -69,8 +69,21 @@ impl<'a> Edge<'a> {
         } = self;
 
         // Retrieve the location and direction of the node sockets.
-        let a_out = ectx.output(ui, a, output).unwrap();
-        let b_in = ectx.input(ui, b, input).unwrap();
+        // If either socket position is unavailable (e.g. sparse explicit
+        // layout), skip rendering entirely.
+        let (a_out, b_in) = match (ectx.output(ui, a, output), ectx.input(ui, b, input)) {
+            (Some(a_out), Some(b_in)) => (a_out, b_in),
+            _ => {
+                let edge_id = ui.id().with(("edge", a, output, b, input));
+                let response = ui.interact(egui::Rect::NOTHING, edge_id, egui::Sense::click());
+                return EdgeResponse {
+                    response,
+                    changed: false,
+                    deleted: false,
+                    closest_point: egui::Pos2::ZERO,
+                };
+            }
+        };
 
         // TODO: Cache the curve and its points?
         let bezier = bezier::Cubic::from_edge_points(a_out, b_in);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "layout")]
 pub use layout::layout;
 pub use node::{NodeCtx, NodeId, NodeInteraction};
-pub use socket_layout::SocketLayout;
+pub use socket_layout::{grid::SocketGrid, SocketLayout};
 
 pub mod bezier;
 pub mod edge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "layout")]
 pub use layout::layout;
 pub use node::{NodeCtx, NodeId, NodeInteraction};
+pub use socket_layout::SocketLayout;
 
 pub mod bezier;
 pub mod edge;
 #[cfg(feature = "layout")]
 pub mod layout;
 pub mod node;
+pub mod socket_layout;
 
 /// The main interface for the `Graph` widget.
 pub struct Graph {
@@ -149,16 +151,8 @@ pub struct Show<'a> {
 #[derive(Clone)]
 pub struct NodeSockets {
     flow: egui::Direction,
-    input: Sockets,
-    output: Sockets,
-}
-
-/// The description of how the inputs and outputs are laid out for a particular node.
-#[derive(Clone)]
-pub struct Sockets {
-    count: usize,
-    start: egui::Pos2,
-    step: egui::Vec2,
+    inputs: BTreeMap<usize, egui::Pos2>,
+    outputs: BTreeMap<usize, egui::Pos2>,
 }
 
 /// A context to assist with the instantiation of node widgets.
@@ -476,44 +470,48 @@ impl NodeSockets {
     ///
     /// Returns `None` if there is no input at the given index.
     pub fn input(&self, ix: usize) -> Option<(egui::Pos2, egui::Vec2)> {
-        if self.input.count <= ix {
-            return None;
-        }
-        let pos = self.input.start + self.input.step * ix as f32;
-        let norm = match self.flow {
-            egui::Direction::LeftToRight => egui::Vec2::new(-1.0, 0.0),
-            egui::Direction::RightToLeft => egui::Vec2::new(1.0, 0.0),
-            egui::Direction::TopDown => egui::Vec2::new(0.0, -1.0),
-            egui::Direction::BottomUp => egui::Vec2::new(0.0, 1.0),
-        };
-        Some((pos, norm))
+        self.inputs
+            .get(&ix)
+            .map(|&pos| (pos, input_normal(self.flow)))
     }
 
-    /// The screen position and normal of the input at the given index.
+    /// The screen position and normal of the output at the given index.
     ///
     /// Returns `None` if there is no output at the given index.
     pub fn output(&self, ix: usize) -> Option<(egui::Pos2, egui::Vec2)> {
-        if self.output.count <= ix {
-            return None;
-        }
-        let pos = self.output.start + self.output.step * ix as f32;
-        let norm = match self.flow {
-            egui::Direction::LeftToRight => egui::Vec2::new(1.0, 0.0),
-            egui::Direction::RightToLeft => egui::Vec2::new(-1.0, 0.0),
-            egui::Direction::TopDown => egui::Vec2::new(0.0, 1.0),
-            egui::Direction::BottomUp => egui::Vec2::new(0.0, -1.0),
-        };
-        Some((pos, norm))
+        self.outputs
+            .get(&ix)
+            .map(|&pos| (pos, output_normal(self.flow)))
     }
 
-    /// Produces an iterator yielding the position and normal for each input.
-    pub fn inputs<'a>(&'a self) -> impl 'a + Iterator<Item = (egui::Pos2, egui::Vec2)> {
-        (0..self.input.count).filter_map(move |ix| self.input(ix))
+    /// Produces an iterator yielding the index, position, and normal for each input.
+    pub fn inputs(&self) -> impl Iterator<Item = (usize, egui::Pos2, egui::Vec2)> + '_ {
+        let norm = input_normal(self.flow);
+        self.inputs.iter().map(move |(&ix, &pos)| (ix, pos, norm))
     }
 
-    /// Produces an iterator yielding the position and normal for each output.
-    pub fn outputs<'a>(&'a self) -> impl 'a + Iterator<Item = (egui::Pos2, egui::Vec2)> {
-        (0..self.output.count).filter_map(move |ix| self.output(ix))
+    /// Produces an iterator yielding the index, position, and normal for each output.
+    pub fn outputs(&self) -> impl Iterator<Item = (usize, egui::Pos2, egui::Vec2)> + '_ {
+        let norm = output_normal(self.flow);
+        self.outputs.iter().map(move |(&ix, &pos)| (ix, pos, norm))
+    }
+}
+
+fn input_normal(flow: egui::Direction) -> egui::Vec2 {
+    match flow {
+        egui::Direction::LeftToRight => egui::Vec2::new(-1.0, 0.0),
+        egui::Direction::RightToLeft => egui::Vec2::new(1.0, 0.0),
+        egui::Direction::TopDown => egui::Vec2::new(0.0, -1.0),
+        egui::Direction::BottomUp => egui::Vec2::new(0.0, 1.0),
+    }
+}
+
+fn output_normal(flow: egui::Direction) -> egui::Vec2 {
+    match flow {
+        egui::Direction::LeftToRight => egui::Vec2::new(1.0, 0.0),
+        egui::Direction::RightToLeft => egui::Vec2::new(-1.0, 0.0),
+        egui::Direction::TopDown => egui::Vec2::new(0.0, 1.0),
+        egui::Direction::BottomUp => egui::Vec2::new(0.0, -1.0),
     }
 }
 
@@ -769,7 +767,7 @@ fn find_closest_socket(
         };
 
         // Check inputs.
-        for (ix, (p, _)) in sockets.inputs().enumerate() {
+        for (ix, p, _) in sockets.inputs() {
             let dist_sq = pos_graph.distance_sq(p);
             if dist_sq < socket_radius_sq {
                 let socket = node::Socket {
@@ -786,7 +784,7 @@ fn find_closest_socket(
         }
 
         // Check outputs.
-        for (ix, (p, _)) in sockets.outputs().enumerate() {
+        for (ix, p, _) in sockets.outputs() {
             let dist_sq = pos_graph.distance_sq(p);
             if dist_sq < socket_radius_sq {
                 let socket = node::Socket {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "layout")]
 pub use layout::layout;
-pub use node::{NodeCtx, NodeId, NodeInteraction};
+pub use node::{FramedResponse, NodeCtx, NodeId, NodeInteraction};
 pub use socket_layout::{grid::SocketGrid, SocketLayout};
 
 pub mod bezier;

--- a/src/node.rs
+++ b/src/node.rs
@@ -104,6 +104,9 @@ pub struct NodeCtx<'a> {
     graph_id: egui::Id,
     node_id: NodeId,
     immutable: bool,
+    flow: egui::Direction,
+    inputs: usize,
+    outputs: usize,
 }
 
 impl Node {
@@ -188,7 +191,7 @@ impl Node {
     ///
     /// ```ignore
     /// Node::from_id(id).show(ctx, ui, |node_ctx| {
-    ///     node_ctx.framed(|ui| {
+    ///     node_ctx.framed(|ui, _sockets| {
     ///         ui.label("Hello");
     ///     })
     /// });
@@ -197,7 +200,7 @@ impl Node {
         self,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
-        content: impl FnOnce(NodeCtx<'_>) -> egui::InnerResponse<R>,
+        content: impl FnOnce(NodeCtx<'_>) -> (egui::InnerResponse<R>, crate::SocketLayout),
     ) -> NodeResponse<R> {
         self.show_impl(ctx, ui, Box::new(content) as Box<_>)
     }
@@ -206,7 +209,7 @@ impl Node {
         self,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
-        content: Box<dyn FnOnce(NodeCtx<'_>) -> egui::InnerResponse<R> + 'a>,
+        content: Box<dyn FnOnce(NodeCtx<'_>) -> (egui::InnerResponse<R>, crate::SocketLayout) + 'a>,
     ) -> NodeResponse<R> {
         let layout = &mut ctx.layout;
 
@@ -351,14 +354,20 @@ impl Node {
                 graph_id: ctx.graph_id,
                 node_id,
                 immutable,
+                flow: self.flow,
+                inputs: self.inputs,
+                outputs: self.outputs,
             };
             content(node_ctx)
         });
 
         // Take the union of the ui scope and the frame response to monitor for
         // interactions.
-        let mut response = inner_response.response.union(inner_response.inner.response);
-        let content_output = inner_response.inner.inner;
+        let (content_inner_response, socket_layout) = inner_response.inner;
+        let mut response = inner_response
+            .response
+            .union(content_inner_response.response);
+        let content_output = content_inner_response.inner;
 
         // Update the stored data for this node and check for edge events.
         let mut edge_event = None;
@@ -451,78 +460,14 @@ impl Node {
             }
         }
 
-        // The inlets/outlets.
-        if self.inputs > 0 || self.outputs > 0 {
-            let in_gap = |len: f32| {
-                if self.inputs > 1 {
-                    len / (self.inputs - 1) as f32
-                } else {
-                    0.0
-                }
-            };
-            let out_gap = |len: f32| {
-                if self.outputs > 1 {
-                    len / (self.outputs - 1) as f32
-                } else {
-                    0.0
-                }
-            };
-            let (mut in_pos, mut out_pos, in_step, out_step) = match self.flow {
-                egui::Direction::LeftToRight => {
-                    let len = response.rect.height() - socket_padding * 2.0;
-                    let in_step = egui::Vec2::new(0.0, in_gap(len));
-                    let out_step = egui::Vec2::new(0.0, out_gap(len));
-                    let start = response.rect.min.y + socket_padding;
-                    let in_pos = egui::Pos2::new(response.rect.min.x, start);
-                    let out_pos = egui::Pos2::new(response.rect.max.x, start);
-                    (in_pos, out_pos, in_step, out_step)
-                }
-                egui::Direction::RightToLeft => {
-                    let len = response.rect.height() - socket_padding * 2.0;
-                    let in_step = egui::Vec2::new(0.0, in_gap(len));
-                    let out_step = egui::Vec2::new(0.0, out_gap(len));
-                    let start = response.rect.min.y + socket_padding;
-                    let in_pos = egui::Pos2::new(response.rect.max.x, start);
-                    let out_pos = egui::Pos2::new(response.rect.min.x, start);
-                    (in_pos, out_pos, in_step, out_step)
-                }
-                egui::Direction::TopDown => {
-                    let len = response.rect.width() - socket_padding * 2.0;
-                    let in_step = egui::Vec2::new(in_gap(len), 0.0);
-                    let out_step = egui::Vec2::new(out_gap(len), 0.0);
-                    let start = response.rect.min.x + socket_padding;
-                    let in_pos = egui::Pos2::new(start, response.rect.min.y);
-                    let out_pos = egui::Pos2::new(start, response.rect.max.y);
-                    (in_pos, out_pos, in_step, out_step)
-                }
-                egui::Direction::BottomUp => {
-                    let len = response.rect.width() - socket_padding * 2.0;
-                    let in_step = egui::Vec2::new(in_gap(len), 0.0);
-                    let out_step = egui::Vec2::new(out_gap(len), 0.0);
-                    let start = response.rect.min.x + socket_padding;
-                    let in_pos = egui::Pos2::new(start, response.rect.max.y);
-                    let out_pos = egui::Pos2::new(start, response.rect.min.y);
-                    (in_pos, out_pos, in_step, out_step)
-                }
-            };
+        // Resolve the socket layout to concrete positions.
+        let node_sockets = socket_layout.resolve(self.flow, response.rect, socket_padding);
 
-            // Store the layout of the sockets for edge instantiation.
-            let sockets = crate::NodeSockets {
-                flow: self.flow,
-                input: crate::Sockets {
-                    count: self.inputs,
-                    start: in_pos,
-                    step: in_step,
-                },
-                output: crate::Sockets {
-                    count: self.outputs,
-                    start: out_pos,
-                    step: out_step,
-                },
-            };
+        // Store resolved sockets and paint them.
+        if !node_sockets.inputs.is_empty() || !node_sockets.outputs.is_empty() {
             let gmem_arc = crate::memory(ui, ctx.graph_id);
             let mut gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
-            gmem.sockets.insert(self.id, sockets);
+            gmem.sockets.insert(self.id, node_sockets.clone());
 
             // Check whether or not this node has a pressed socket.
             let pressed_socket = gmem
@@ -568,19 +513,17 @@ impl Node {
             let color = self.socket_color.unwrap_or(ui.visuals().text_color());
             let hl_size = (self.socket_radius + 4.0).max(4.0);
             let painter = ui.painter();
-            for ix in 0..self.inputs {
+            for (ix, pos, _) in node_sockets.inputs() {
                 if paint_highlight(SocketKind::Input, ix) {
-                    painter.circle_filled(in_pos, hl_size, color.linear_multiply(0.25));
+                    painter.circle_filled(pos, hl_size, color.linear_multiply(0.25));
                 }
-                painter.circle_filled(in_pos, self.socket_radius, color);
-                in_pos += in_step;
+                painter.circle_filled(pos, self.socket_radius, color);
             }
-            for ix in 0..self.outputs {
+            for (ix, pos, _) in node_sockets.outputs() {
                 if paint_highlight(SocketKind::Output, ix) {
-                    painter.circle_filled(out_pos, hl_size, color.linear_multiply(0.25));
+                    painter.circle_filled(pos, hl_size, color.linear_multiply(0.25));
                 }
-                painter.circle_filled(out_pos, self.socket_radius, color);
-                out_pos += out_step;
+                painter.circle_filled(pos, self.socket_radius, color);
             }
         }
 
@@ -736,13 +679,20 @@ impl<'a> NodeCtx<'a> {
     ///
     /// This consumes the context, ensuring content is only added once.
     ///
-    /// Returns the combined response from the frame and content area. This response:
+    /// Returns the combined response and socket layout. The response:
     /// - Has a rect covering the entire framed area.
     /// - Reports interactions (clicks, drags, hovers) on any part of the node.
     /// - Is used by [`Node::show`] for selection and drag handling.
     ///
+    /// The content closure receives a `&mut SocketLayout` which can be used to
+    /// register explicit socket positions (e.g. via [`SocketLayout::row`]).
+    /// If left unmodified, sockets are evenly spaced along the node edge.
+    ///
     /// For custom frame styling, use [`NodeCtx::framed_with`].
-    pub fn framed<T>(self, content: impl FnOnce(&mut egui::Ui) -> T) -> egui::InnerResponse<T> {
+    pub fn framed<T>(
+        self,
+        content: impl FnOnce(&mut egui::Ui, &mut crate::SocketLayout) -> T,
+    ) -> (egui::InnerResponse<T>, crate::SocketLayout) {
         let frame = default_frame(self.style(), self.interaction);
         self.framed_with(frame, content)
     }
@@ -751,19 +701,24 @@ impl<'a> NodeCtx<'a> {
     ///
     /// This consumes the context, ensuring content is only added once.
     ///
-    /// Returns the combined response from the frame and content area. This response:
+    /// Returns the combined response and socket layout. The response:
     /// - Has a rect covering the entire framed area.
     /// - Reports interactions (clicks, drags, hovers) on any part of the node.
     /// - Is used by [`Node::show`] for selection and drag handling.
+    ///
+    /// The content closure receives a `&mut SocketLayout` which can be used to
+    /// register explicit socket positions (e.g. via [`SocketLayout::row`]).
+    /// If left unmodified, sockets are evenly spaced along the node edge.
     ///
     /// For default frame styling, use [`NodeCtx::framed`].
     pub fn framed_with<T>(
         self,
         frame: egui::Frame,
-        content: impl FnOnce(&mut egui::Ui) -> T,
-    ) -> egui::InnerResponse<T> {
+        content: impl FnOnce(&mut egui::Ui, &mut crate::SocketLayout) -> T,
+    ) -> (egui::InnerResponse<T>, crate::SocketLayout) {
         let min_size = self.min_size;
         let immutable = self.immutable;
+        let mut socket_layout = crate::SocketLayout::auto(self.flow, self.inputs, self.outputs);
         let builder = egui::UiBuilder::new().sense(egui::Sense::click_and_drag());
         let inner_response = frame.show(self.ui, |ui| {
             ui.scope_builder(builder, |ui| {
@@ -773,12 +728,15 @@ impl<'a> NodeCtx<'a> {
                 if immutable {
                     ui.disable();
                 }
-                content(ui)
+                content(ui, &mut socket_layout)
             })
         });
         let response = inner_response.response.union(inner_response.inner.response);
         let content_output = inner_response.inner.inner;
-        egui::InnerResponse::new(content_output, response)
+        (
+            egui::InnerResponse::new(content_output, response),
+            socket_layout,
+        )
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -81,6 +81,15 @@ pub struct NodeResponse<T> {
     edge_event: Option<EdgeEvent>,
 }
 
+/// The response returned by [`NodeCtx::framed`] and [`NodeCtx::framed_with`].
+///
+/// Carries the content's [`egui::InnerResponse`] alongside the
+/// [`SocketLayout`] describing socket positions for this node.
+pub struct FramedResponse<T> {
+    pub inner: egui::InnerResponse<T>,
+    pub sockets: crate::SocketLayout,
+}
+
 /// Events related to the creation of an edge to or from a node.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum EdgeEvent {
@@ -200,7 +209,7 @@ impl Node {
         self,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
-        content: impl FnOnce(NodeCtx<'_>) -> (egui::InnerResponse<R>, crate::SocketLayout),
+        content: impl FnOnce(NodeCtx<'_>) -> FramedResponse<R>,
     ) -> NodeResponse<R> {
         self.show_impl(ctx, ui, Box::new(content) as Box<_>)
     }
@@ -209,7 +218,7 @@ impl Node {
         self,
         ctx: &mut NodesCtx,
         ui: &mut egui::Ui,
-        content: Box<dyn FnOnce(NodeCtx<'_>) -> (egui::InnerResponse<R>, crate::SocketLayout) + 'a>,
+        content: Box<dyn FnOnce(NodeCtx<'_>) -> FramedResponse<R> + 'a>,
     ) -> NodeResponse<R> {
         let layout = &mut ctx.layout;
 
@@ -363,7 +372,10 @@ impl Node {
 
         // Take the union of the ui scope and the frame response to monitor for
         // interactions.
-        let (content_inner_response, socket_layout) = inner_response.inner;
+        let FramedResponse {
+            inner: content_inner_response,
+            sockets: socket_layout,
+        } = inner_response.inner;
         let mut response = inner_response
             .response
             .union(content_inner_response.response);
@@ -679,7 +691,8 @@ impl<'a> NodeCtx<'a> {
     ///
     /// This consumes the context, ensuring content is only added once.
     ///
-    /// Returns the combined response and socket layout. The response:
+    /// Returns a [`FramedResponse`] containing the combined response and
+    /// socket layout. The response:
     /// - Has a rect covering the entire framed area.
     /// - Reports interactions (clicks, drags, hovers) on any part of the node.
     /// - Is used by [`Node::show`] for selection and drag handling.
@@ -692,7 +705,7 @@ impl<'a> NodeCtx<'a> {
     pub fn framed<T>(
         self,
         content: impl FnOnce(&mut egui::Ui, &mut crate::SocketLayout) -> T,
-    ) -> (egui::InnerResponse<T>, crate::SocketLayout) {
+    ) -> FramedResponse<T> {
         let frame = default_frame(self.style(), self.interaction);
         self.framed_with(frame, content)
     }
@@ -701,7 +714,8 @@ impl<'a> NodeCtx<'a> {
     ///
     /// This consumes the context, ensuring content is only added once.
     ///
-    /// Returns the combined response and socket layout. The response:
+    /// Returns a [`FramedResponse`] containing the combined response and
+    /// socket layout. The response:
     /// - Has a rect covering the entire framed area.
     /// - Reports interactions (clicks, drags, hovers) on any part of the node.
     /// - Is used by [`Node::show`] for selection and drag handling.
@@ -715,7 +729,7 @@ impl<'a> NodeCtx<'a> {
         self,
         frame: egui::Frame,
         content: impl FnOnce(&mut egui::Ui, &mut crate::SocketLayout) -> T,
-    ) -> (egui::InnerResponse<T>, crate::SocketLayout) {
+    ) -> FramedResponse<T> {
         let min_size = self.min_size;
         let immutable = self.immutable;
         let mut socket_layout =
@@ -734,10 +748,10 @@ impl<'a> NodeCtx<'a> {
         });
         let response = inner_response.response.union(inner_response.inner.response);
         let content_output = inner_response.inner.inner;
-        (
-            egui::InnerResponse::new(content_output, response),
-            socket_layout,
-        )
+        FramedResponse {
+            inner: egui::InnerResponse::new(content_output, response),
+            sockets: socket_layout,
+        }
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -718,7 +718,8 @@ impl<'a> NodeCtx<'a> {
     ) -> (egui::InnerResponse<T>, crate::SocketLayout) {
         let min_size = self.min_size;
         let immutable = self.immutable;
-        let mut socket_layout = crate::SocketLayout::auto(self.flow, self.inputs, self.outputs);
+        let mut socket_layout =
+            crate::SocketLayout::evenly_spaced(self.flow, self.inputs, self.outputs);
         let builder = egui::UiBuilder::new().sense(egui::Sense::click_and_drag());
         let inner_response = frame.show(self.ui, |ui| {
             ui.scope_builder(builder, |ui| {

--- a/src/socket_layout.rs
+++ b/src/socket_layout.rs
@@ -30,20 +30,32 @@ impl SocketLayout {
         }
     }
 
+    /// Set an input socket's explicit cross-axis position.
+    ///
+    /// Switches to explicit positioning on first call.
+    pub fn input_at(&mut self, ix: usize, cross: f32) {
+        self.inputs.set_explicit(ix, cross);
+    }
+
+    /// Set an output socket's explicit cross-axis position.
+    ///
+    /// Switches to explicit positioning on first call.
+    pub fn output_at(&mut self, ix: usize, cross: f32) {
+        self.outputs.set_explicit(ix, cross);
+    }
+
     /// Register an input socket aligned with the cross-axis center of `rect`.
     ///
     /// Switches to explicit positioning on first call.
     pub fn input(&mut self, ix: usize, rect: egui::Rect) {
-        let cross = cross_axis_center(self.flow, rect);
-        self.inputs.set_explicit(ix, cross);
+        self.input_at(ix, cross_axis_center(self.flow, rect));
     }
 
     /// Register an output socket aligned with the cross-axis center of `rect`.
     ///
     /// Switches to explicit positioning on first call.
     pub fn output(&mut self, ix: usize, rect: egui::Rect) {
-        let cross = cross_axis_center(self.flow, rect);
-        self.outputs.set_explicit(ix, cross);
+        self.output_at(ix, cross_axis_center(self.flow, rect));
     }
 
     /// Render content in a `ui.scope`, registering sockets aligned with its

--- a/src/socket_layout.rs
+++ b/src/socket_layout.rs
@@ -1,0 +1,208 @@
+use crate::NodeSockets;
+use std::collections::BTreeMap;
+
+/// Controls how socket positions are determined for a node.
+///
+/// Pre-initialized as `Auto` from the `Node` builder's input/output counts.
+/// Users can ignore it for automatic spacing, or switch to explicit positioning
+/// via [`SocketLayout::input`], [`SocketLayout::output`], or [`SocketLayout::row`].
+pub struct SocketLayout {
+    flow: egui::Direction,
+    inputs: SocketPositions,
+    outputs: SocketPositions,
+}
+
+enum SocketPositions {
+    /// Evenly spaced along the edge (current behavior).
+    Auto(usize),
+    /// Explicit cross-axis positions. Only positioned sockets are rendered.
+    Explicit(BTreeMap<usize, f32>),
+}
+
+impl SocketLayout {
+    /// Create a new `SocketLayout` in auto mode with the given socket counts.
+    pub fn auto(flow: egui::Direction, inputs: usize, outputs: usize) -> Self {
+        Self {
+            flow,
+            inputs: SocketPositions::Auto(inputs),
+            outputs: SocketPositions::Auto(outputs),
+        }
+    }
+
+    /// Register an input socket aligned with the cross-axis center of `rect`.
+    ///
+    /// Switches to explicit positioning on first call.
+    pub fn input(&mut self, ix: usize, rect: egui::Rect) {
+        let cross = cross_axis_center(self.flow, rect);
+        self.inputs.set_explicit(ix, cross);
+    }
+
+    /// Register an output socket aligned with the cross-axis center of `rect`.
+    ///
+    /// Switches to explicit positioning on first call.
+    pub fn output(&mut self, ix: usize, rect: egui::Rect) {
+        let cross = cross_axis_center(self.flow, rect);
+        self.outputs.set_explicit(ix, cross);
+    }
+
+    /// Render content in a `ui.scope`, registering sockets aligned with its
+    /// cross-axis center.
+    pub fn row<R>(
+        &mut self,
+        ui: &mut egui::Ui,
+        input: Option<usize>,
+        output: Option<usize>,
+        content: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> egui::InnerResponse<R> {
+        let ir = ui.scope(content);
+        if let Some(ix) = input {
+            self.input(ix, ir.response.rect);
+        }
+        if let Some(ix) = output {
+            self.output(ix, ir.response.rect);
+        }
+        ir
+    }
+
+    /// Resolve the layout into concrete `NodeSockets` given the final frame
+    /// rect and socket padding.
+    pub(crate) fn resolve(
+        self,
+        flow: egui::Direction,
+        rect: egui::Rect,
+        socket_padding: f32,
+    ) -> NodeSockets {
+        let inputs = resolve_positions(&self.inputs, flow, rect, socket_padding, true);
+        let outputs = resolve_positions(&self.outputs, flow, rect, socket_padding, false);
+        NodeSockets {
+            flow,
+            inputs,
+            outputs,
+        }
+    }
+}
+
+impl SocketPositions {
+    fn set_explicit(&mut self, ix: usize, cross: f32) {
+        match self {
+            SocketPositions::Auto(_) => {
+                let mut map = BTreeMap::new();
+                map.insert(ix, cross);
+                *self = SocketPositions::Explicit(map);
+            }
+            SocketPositions::Explicit(map) => {
+                map.insert(ix, cross);
+            }
+        }
+    }
+}
+
+/// The cross-axis center of a rect relative to the flow direction.
+fn cross_axis_center(flow: egui::Direction, rect: egui::Rect) -> f32 {
+    match flow {
+        egui::Direction::LeftToRight | egui::Direction::RightToLeft => rect.center().y,
+        egui::Direction::TopDown | egui::Direction::BottomUp => rect.center().x,
+    }
+}
+
+/// Resolve a `SocketPositions` into a `BTreeMap<usize, Pos2>`.
+fn resolve_positions(
+    positions: &SocketPositions,
+    flow: egui::Direction,
+    rect: egui::Rect,
+    socket_padding: f32,
+    is_input: bool,
+) -> BTreeMap<usize, egui::Pos2> {
+    match positions {
+        SocketPositions::Auto(count) => resolve_auto(*count, flow, rect, socket_padding, is_input),
+        SocketPositions::Explicit(map) => resolve_explicit(map, flow, rect, is_input),
+    }
+}
+
+/// Auto mode: evenly space sockets along the edge (existing behavior).
+fn resolve_auto(
+    count: usize,
+    flow: egui::Direction,
+    rect: egui::Rect,
+    socket_padding: f32,
+    is_input: bool,
+) -> BTreeMap<usize, egui::Pos2> {
+    let mut result = BTreeMap::new();
+    if count == 0 {
+        return result;
+    }
+    let gap = |len: f32| {
+        if count > 1 {
+            len / (count - 1) as f32
+        } else {
+            0.0
+        }
+    };
+    let (start, step) = match flow {
+        egui::Direction::LeftToRight => {
+            let len = rect.height() - socket_padding * 2.0;
+            let main_x = if is_input { rect.min.x } else { rect.max.x };
+            let start = egui::Pos2::new(main_x, rect.min.y + socket_padding);
+            let step = egui::Vec2::new(0.0, gap(len));
+            (start, step)
+        }
+        egui::Direction::RightToLeft => {
+            let len = rect.height() - socket_padding * 2.0;
+            let main_x = if is_input { rect.max.x } else { rect.min.x };
+            let start = egui::Pos2::new(main_x, rect.min.y + socket_padding);
+            let step = egui::Vec2::new(0.0, gap(len));
+            (start, step)
+        }
+        egui::Direction::TopDown => {
+            let len = rect.width() - socket_padding * 2.0;
+            let main_y = if is_input { rect.min.y } else { rect.max.y };
+            let start = egui::Pos2::new(rect.min.x + socket_padding, main_y);
+            let step = egui::Vec2::new(gap(len), 0.0);
+            (start, step)
+        }
+        egui::Direction::BottomUp => {
+            let len = rect.width() - socket_padding * 2.0;
+            let main_y = if is_input { rect.max.y } else { rect.min.y };
+            let start = egui::Pos2::new(rect.min.x + socket_padding, main_y);
+            let step = egui::Vec2::new(gap(len), 0.0);
+            (start, step)
+        }
+    };
+    for ix in 0..count {
+        result.insert(ix, start + step * ix as f32);
+    }
+    result
+}
+
+/// Explicit mode: place sockets at the main-axis edge, using the stored
+/// cross-axis positions.
+fn resolve_explicit(
+    map: &BTreeMap<usize, f32>,
+    flow: egui::Direction,
+    rect: egui::Rect,
+    is_input: bool,
+) -> BTreeMap<usize, egui::Pos2> {
+    map.iter()
+        .map(|(&ix, &cross)| {
+            let pos = match flow {
+                egui::Direction::LeftToRight => {
+                    let main_x = if is_input { rect.min.x } else { rect.max.x };
+                    egui::Pos2::new(main_x, cross)
+                }
+                egui::Direction::RightToLeft => {
+                    let main_x = if is_input { rect.max.x } else { rect.min.x };
+                    egui::Pos2::new(main_x, cross)
+                }
+                egui::Direction::TopDown => {
+                    let main_y = if is_input { rect.min.y } else { rect.max.y };
+                    egui::Pos2::new(cross, main_y)
+                }
+                egui::Direction::BottomUp => {
+                    let main_y = if is_input { rect.max.y } else { rect.min.y };
+                    egui::Pos2::new(cross, main_y)
+                }
+            };
+            (ix, pos)
+        })
+        .collect()
+}

--- a/src/socket_layout.rs
+++ b/src/socket_layout.rs
@@ -1,3 +1,5 @@
+pub mod grid;
+
 use crate::NodeSockets;
 use std::collections::BTreeMap;
 

--- a/src/socket_layout.rs
+++ b/src/socket_layout.rs
@@ -3,9 +3,10 @@ use std::collections::BTreeMap;
 
 /// Controls how socket positions are determined for a node.
 ///
-/// Pre-initialized as `Auto` from the `Node` builder's input/output counts.
+/// Pre-initialized as `EvenlySpaced` from the `Node` builder's input/output counts.
 /// Users can ignore it for automatic spacing, or switch to explicit positioning
-/// via [`SocketLayout::input`], [`SocketLayout::output`], or [`SocketLayout::row`].
+/// via [`SocketLayout::input`], [`SocketLayout::output`], [`SocketLayout::row`],
+/// or [`SocketLayout::col`].
 pub struct SocketLayout {
     flow: egui::Direction,
     inputs: SocketPositions,
@@ -14,18 +15,18 @@ pub struct SocketLayout {
 
 enum SocketPositions {
     /// Evenly spaced along the edge (current behavior).
-    Auto(usize),
+    EvenlySpaced(usize),
     /// Explicit cross-axis positions. Only positioned sockets are rendered.
     Explicit(BTreeMap<usize, f32>),
 }
 
 impl SocketLayout {
-    /// Create a new `SocketLayout` in auto mode with the given socket counts.
-    pub fn auto(flow: egui::Direction, inputs: usize, outputs: usize) -> Self {
+    /// Create a new `SocketLayout` that evenly spaces sockets along the node edge.
+    pub fn evenly_spaced(flow: egui::Direction, inputs: usize, outputs: usize) -> Self {
         Self {
             flow,
-            inputs: SocketPositions::Auto(inputs),
-            outputs: SocketPositions::Auto(outputs),
+            inputs: SocketPositions::EvenlySpaced(inputs),
+            outputs: SocketPositions::EvenlySpaced(outputs),
         }
     }
 
@@ -46,8 +47,8 @@ impl SocketLayout {
     }
 
     /// Render content in a `ui.scope`, registering sockets aligned with its
-    /// cross-axis center.
-    pub fn row<R>(
+    /// cross-axis center. Shared logic for `row` and `col`.
+    fn aligned<R>(
         &mut self,
         ui: &mut egui::Ui,
         input: Option<usize>,
@@ -62,6 +63,28 @@ impl SocketLayout {
             self.output(ix, ir.response.rect);
         }
         ir
+    }
+
+    /// Register sockets aligned with a row of content (horizontal flows).
+    pub fn row<R>(
+        &mut self,
+        ui: &mut egui::Ui,
+        input: Option<usize>,
+        output: Option<usize>,
+        content: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> egui::InnerResponse<R> {
+        self.aligned(ui, input, output, content)
+    }
+
+    /// Register sockets aligned with a column of content (vertical flows).
+    pub fn col<R>(
+        &mut self,
+        ui: &mut egui::Ui,
+        input: Option<usize>,
+        output: Option<usize>,
+        content: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> egui::InnerResponse<R> {
+        self.aligned(ui, input, output, content)
     }
 
     /// Resolve the layout into concrete `NodeSockets` given the final frame
@@ -85,7 +108,7 @@ impl SocketLayout {
 impl SocketPositions {
     fn set_explicit(&mut self, ix: usize, cross: f32) {
         match self {
-            SocketPositions::Auto(_) => {
+            SocketPositions::EvenlySpaced(_) => {
                 let mut map = BTreeMap::new();
                 map.insert(ix, cross);
                 *self = SocketPositions::Explicit(map);
@@ -114,13 +137,15 @@ fn resolve_positions(
     is_input: bool,
 ) -> BTreeMap<usize, egui::Pos2> {
     match positions {
-        SocketPositions::Auto(count) => resolve_auto(*count, flow, rect, socket_padding, is_input),
+        SocketPositions::EvenlySpaced(count) => {
+            resolve_evenly_spaced(*count, flow, rect, socket_padding, is_input)
+        }
         SocketPositions::Explicit(map) => resolve_explicit(map, flow, rect, is_input),
     }
 }
 
-/// Auto mode: evenly space sockets along the edge (existing behavior).
-fn resolve_auto(
+/// Evenly space sockets along the edge.
+fn resolve_evenly_spaced(
     count: usize,
     flow: egui::Direction,
     rect: egui::Rect,

--- a/src/socket_layout/grid.rs
+++ b/src/socket_layout/grid.rs
@@ -1,0 +1,60 @@
+use super::SocketLayout;
+
+/// Helper for registering sockets aligned with rows inside an [`egui::Grid`].
+///
+/// Created by [`SocketLayout::grid`]. Each call to [`SocketGrid::row`] adds
+/// content cells to the grid and registers input/output sockets at the row's
+/// cross-axis center.
+pub struct SocketGrid<'a> {
+    layout: &'a mut SocketLayout,
+}
+
+impl SocketLayout {
+    /// Render content inside an [`egui::Grid`], registering sockets aligned
+    /// with individual rows via [`SocketGrid::row`].
+    ///
+    /// The caller provides a pre-configured [`egui::Grid`] for full control
+    /// over spacing, striping, etc. Widgets placed within each
+    /// [`SocketGrid::row`] closure become grid cells, and `egui::Grid` aligns
+    /// columns across rows.
+    pub fn grid<R>(
+        &mut self,
+        grid: egui::Grid,
+        ui: &mut egui::Ui,
+        content: impl FnOnce(&mut SocketGrid<'_>, &mut egui::Ui) -> R,
+    ) -> egui::InnerResponse<R> {
+        grid.show(ui, |ui| {
+            let mut sg = SocketGrid { layout: self };
+            content(&mut sg, ui)
+        })
+    }
+}
+
+impl SocketGrid<'_> {
+    /// Add a row of content to the grid, optionally registering input and
+    /// output sockets at the row's cross-axis center.
+    ///
+    /// Widgets added by `content` become cells in the current grid row.
+    /// After the content, `ui.end_row()` is called automatically.
+    pub fn row<R>(
+        &mut self,
+        ui: &mut egui::Ui,
+        input: Option<usize>,
+        output: Option<usize>,
+        content: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> R {
+        let row_top = ui.cursor().top();
+        let r = content(ui);
+        ui.end_row();
+        let next_row_top = ui.cursor().top();
+        let spacing = ui.spacing().item_spacing.y;
+        let cross = row_top + (next_row_top - row_top - spacing) / 2.0;
+        if let Some(ix) = input {
+            self.layout.input_at(ix, cross);
+        }
+        if let Some(ix) = output {
+            self.layout.output_at(ix, cross);
+        }
+        r
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `SocketLayout` type that decouples socket positioning from the node widget, supporting both evenly-spaced (default) and explicit positioning modes.
- Add row/col helpers to align sockets with content, and `input_at`/`output_at` for direct cross-axis positioning.
- Switch `NodeSockets` internals from contiguous (count, start, step) to sparse `BTreeMap<usize, Pos2>`, enabling partial/explicit layouts.

## Breaking changes

- `Node::show` content closure now returns `(InnerResponse<T>, SocketLayout)`.
- `NodeCtx::framed`/`framed_with` content closures receive a &mut SocketLayout parameter.
- `NodeSockets::inputs()`/`outputs()` iterators now yield `(usize, Pos2, Vec2)` instead of `(Pos2, Vec2)`.
- Sockets struct removed in favour of BTreeMap-backed storage.

Closes #32 
Closes #33