### PR TITLE
feat: deterministic `View.layout` serialization via sorted keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_graph"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,15 @@ struct PressedNode {
 pub struct View {
     /// The visible area of the graph's [`Scene`][egui::containers::Scene].
     pub scene_rect: egui::Rect,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_sorted_layout"))]
     pub layout: Layout,
+}
+
+#[cfg(feature = "serde")]
+fn serialize_sorted_layout<S: serde::Serializer>(layout: &Layout, s: S) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+    let sorted: BTreeMap<_, _> = layout.iter().collect();
+    sorted.serialize(s)
 }
 
 /// The location of the top-left of each node relative to the centre of the graph area.


### PR DESCRIPTION
Add a serde-gated `serialize_sorted_layout` helper that collects the `Layout` `HashMap` into a `BTreeMap` before serializing, producing deterministic key order and eliminating spurious diffs when re-saving unchanged data.