### PR TITLE
Add edge curvature and collapsed node sizing

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -26,8 +26,8 @@ struct State {
     custom_edge_style: bool,
     edge_width: f32,
     edge_color: egui::Color32,
-    #[cfg(feature = "layout")]
     edge_curvature: f32,
+    #[cfg(feature = "layout")]
     auto_layout: bool,
     node_spacing: [f32; 2],
     node_id_map: HashMap<egui_graph::NodeId, NodeIndex>,
@@ -424,10 +424,6 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
                 ui.label("Flow:");
                 ui.radio_value(&mut state.flow, egui::Direction::LeftToRight, "Right");
                 ui.radio_value(&mut state.flow, egui::Direction::TopDown, "Down");
-            });
-            ui.horizontal(|ui| {
-                ui.label("Edge curvature:");
-                ui.add(egui::Slider::new(&mut state.edge_curvature, 0.0..=1.0));
             });
             ui.horizontal(|ui| {
                 ui.label("Edge curvature:");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -387,11 +387,7 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
 
     // Draw the in-progress edge if there is one.
     if let Some(edge) = ectx.in_progress(ui) {
-        let dist_per_pt = egui_graph::edge::Edge::DEFAULT_DISTANCE_PER_POINT;
-        let bezier = edge.bezier_cubic_with_curvature(state.edge_curvature);
-        let pts = bezier.flatten(dist_per_pt).collect();
-        let stroke = ui.visuals().widgets.active.fg_stroke;
-        ui.painter().add(egui::Shape::line(pts, stroke));
+        edge.show(ui, state.edge_curvature);
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -27,6 +27,7 @@ struct State {
     edge_width: f32,
     edge_color: egui::Color32,
     #[cfg(feature = "layout")]
+    edge_curvature: f32,
     auto_layout: bool,
     node_spacing: [f32; 2],
     node_id_map: HashMap<egui_graph::NodeId, NodeIndex>,
@@ -80,6 +81,7 @@ impl App {
             custom_edge_style: false,
             edge_width: 1.0,
             edge_color: ctx.style().visuals.weak_text_color(),
+            edge_curvature: 0.5,
             flow: egui::Direction::TopDown,
             #[cfg(feature = "layout")]
             auto_layout: true,
@@ -367,8 +369,9 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
         let a = egui_graph::NodeId::from_u64(na.index() as u64);
         let b = egui_graph::NodeId::from_u64(nb.index() as u64);
         let mut selected = state.interaction.selection.edges.contains(&e);
-        let response =
-            egui_graph::edge::Edge::new((a, output), (b, input), &mut selected).show(ectx, ui);
+        let response = egui_graph::edge::Edge::new((a, output), (b, input), &mut selected)
+            .curvature_factor(state.edge_curvature)
+            .show(ectx, ui);
 
         if response.deleted() {
             state.graph.remove_edge(e);
@@ -384,7 +387,11 @@ fn edges(ectx: &mut egui_graph::EdgesCtx, ui: &mut egui::Ui, state: &mut State) 
 
     // Draw the in-progress edge if there is one.
     if let Some(edge) = ectx.in_progress(ui) {
-        edge.show(ui);
+        let dist_per_pt = egui_graph::edge::Edge::DEFAULT_DISTANCE_PER_POINT;
+        let bezier = edge.bezier_cubic_with_curvature(state.edge_curvature);
+        let pts = bezier.flatten(dist_per_pt).collect();
+        let stroke = ui.visuals().widgets.active.fg_stroke;
+        ui.painter().add(egui::Shape::line(pts, stroke));
     }
 }
 
@@ -421,6 +428,14 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
                 ui.label("Flow:");
                 ui.radio_value(&mut state.flow, egui::Direction::LeftToRight, "Right");
                 ui.radio_value(&mut state.flow, egui::Direction::TopDown, "Down");
+            });
+            ui.horizontal(|ui| {
+                ui.label("Edge curvature:");
+                ui.add(egui::Slider::new(&mut state.edge_curvature, 0.0..=1.0));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Edge curvature:");
+                ui.add(egui::Slider::new(&mut state.edge_curvature, 0.0..=1.0));
             });
             ui.horizontal(|ui| {
                 ui.label("Node spacing X:");

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -81,7 +81,7 @@ impl Cubic {
     /// simple edge selection (the main use-case for this method).
     pub fn closest_point(self, distance_per_point: f32, target: egui::Pos2) -> egui::Pos2 {
         self.flatten(distance_per_point)
-            .fold((self.from, std::f32::MAX), |closest, p| {
+            .fold((self.from, f32::MAX), |closest, p| {
                 let dist_sq = p.distance_sq(target);
                 if dist_sq < closest.1 {
                     (p, dist_sq)

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -9,7 +9,7 @@ pub struct Cubic {
 
 impl Cubic {
     /// Maximum proportion of the socket-to-socket distance used for control points.
-    pub const MAX_CURVATURE_FACTOR: f32 = 0.5;
+    pub(crate) const MAX_CURVATURE_FACTOR: f32 = 0.5;
     /// Default normalized curvature value.
     pub const DEFAULT_CURVATURE: f32 = 0.5;
 

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -8,16 +8,37 @@ pub struct Cubic {
 }
 
 impl Cubic {
+    /// Maximum proportion of the socket-to-socket distance used for control points.
+    pub const MAX_CURVATURE_FACTOR: f32 = 0.5;
+    /// Default normalized curvature value.
+    pub const DEFAULT_CURVATURE: f32 = 0.5;
+
     /// Construct a cubic curve from the start and end points (and normals) of an edge.
     ///
     /// The normals of the associated input/output are required in order to determine ctrl points.
     pub fn from_edge_points(a: (egui::Pos2, egui::Vec2), b: (egui::Pos2, egui::Vec2)) -> Self {
+        Self::from_edge_points_with_curvature(a, b, Self::DEFAULT_CURVATURE)
+    }
+
+    /// Construct a cubic curve using a custom curvature factor.
+    ///
+    /// `curvature` is a normalized value in the range `0.0..=1.0`.
+    ///
+    /// Internally this maps to a control-point distance factor in the range
+    /// `0.0..=Self::MAX_CURVATURE_FACTOR`, capping the strongest curve at half
+    /// of the total socket-to-socket distance.
+    pub fn from_edge_points_with_curvature(
+        a: (egui::Pos2, egui::Vec2),
+        b: (egui::Pos2, egui::Vec2),
+        curvature: f32,
+    ) -> Self {
         let (from, a_norm) = a;
         let (to, b_norm) = b;
         let distance = from.distance(to);
-        let half_distance = distance * 0.5;
-        let ctrl1 = from + a_norm * half_distance;
-        let ctrl2 = to + b_norm * half_distance;
+        let curvature_factor = curvature.clamp(0.0, 1.0) * Self::MAX_CURVATURE_FACTOR;
+        let ctrl_distance = distance * curvature_factor;
+        let ctrl1 = from + a_norm * ctrl_distance;
+        let ctrl2 = to + b_norm * ctrl_distance;
         Self {
             from,
             ctrl1,

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -16,18 +16,11 @@ impl Cubic {
     /// Construct a cubic curve from the start and end points (and normals) of an edge.
     ///
     /// The normals of the associated input/output are required in order to determine ctrl points.
-    pub fn from_edge_points(a: (egui::Pos2, egui::Vec2), b: (egui::Pos2, egui::Vec2)) -> Self {
-        Self::from_edge_points_with_curvature(a, b, Self::DEFAULT_CURVATURE)
-    }
-
-    /// Construct a cubic curve using a custom curvature factor.
     ///
     /// `curvature` is a normalized value in the range `0.0..=1.0`.
-    ///
-    /// Internally this maps to a control-point distance factor in the range
-    /// `0.0..=Self::MAX_CURVATURE_FACTOR`, capping the strongest curve at half
-    /// of the total socket-to-socket distance.
-    pub fn from_edge_points_with_curvature(
+    /// Internally this maps to a control-point distance factor capping the
+    /// strongest curve at half of the total socket-to-socket distance.
+    pub fn from_edge_points(
         a: (egui::Pos2, egui::Vec2),
         b: (egui::Pos2, egui::Vec2),
         curvature: f32,

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -101,7 +101,7 @@ impl<'a> Edge<'a> {
         };
 
         // TODO: Cache the curve and its points?
-        let bezier = bezier::Cubic::from_edge_points_with_curvature(a_out, b_in, curvature);
+        let bezier = bezier::Cubic::from_edge_points(a_out, b_in, curvature);
 
         // Get the mouse position for computing the closest point on the edge.
         let ui_response = ui.response();

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -143,10 +143,9 @@ impl<'a> Edge<'a> {
             {
                 *selected = false;
             }
-        } else if clicked {
-            *selected = true;
-        } else if under_selection_rect
-            && ui.input(|i| i.modifiers.shift && i.pointer.primary_released())
+        } else if clicked
+            || (under_selection_rect
+                && ui.input(|i| i.modifiers.shift && i.pointer.primary_released()))
         {
             *selected = true;
         }
@@ -172,9 +171,7 @@ impl<'a> Edge<'a> {
         let pts: Vec<_> = bezier.flatten(distance_per_point).collect();
         let stroke = if *selected {
             ui.style().visuals.selection.stroke
-        } else if show_hover {
-            ui.style().visuals.widgets.hovered.fg_stroke
-        } else if under_selection_rect && ui.input(|i| i.modifiers.shift) {
+        } else if show_hover || (under_selection_rect && ui.input(|i| i.modifiers.shift)) {
             ui.style().visuals.widgets.hovered.fg_stroke
         } else {
             ui.style().visuals.widgets.noninteractive.fg_stroke

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -14,6 +14,7 @@ use std::ops;
 pub struct Edge<'a> {
     edge: ((NodeId, OutputIx), (NodeId, InputIx)),
     distance_per_point: f32,
+    curvature: f32,
     selected: &'a mut bool,
 }
 
@@ -43,6 +44,7 @@ impl<'a> Edge<'a> {
         Self {
             edge: (a, b),
             distance_per_point: Self::DEFAULT_DISTANCE_PER_POINT,
+            curvature: bezier::Cubic::DEFAULT_CURVATURE,
             selected,
         }
     }
@@ -60,11 +62,24 @@ impl<'a> Edge<'a> {
         self
     }
 
+    /// Set the normalized curvature used when constructing the edge bezier.
+    ///
+    /// Values are clamped to `0.0..=1.0` and then scaled internally so the
+    /// strongest curve uses at most half the socket-to-socket distance for its
+    /// control points.
+    ///
+    /// Default: [`bezier::Cubic::DEFAULT_CURVATURE`].
+    pub fn curvature_factor(mut self, curvature: f32) -> Self {
+        self.curvature = curvature;
+        self
+    }
+
     /// Process any user interaction with the edge and present it.
     pub fn show(self, ectx: &mut EdgesCtx, ui: &mut egui::Ui) -> EdgeResponse {
         let Self {
             edge: ((a, output), (b, input)),
             distance_per_point,
+            curvature,
             selected,
         } = self;
 
@@ -86,7 +101,7 @@ impl<'a> Edge<'a> {
         };
 
         // TODO: Cache the curve and its points?
-        let bezier = bezier::Cubic::from_edge_points(a_out, b_in);
+        let bezier = bezier::Cubic::from_edge_points_with_curvature(a_out, b_in, curvature);
 
         // Get the mouse position for computing the closest point on the edge.
         let ui_response = ui.response();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ impl Graph {
 
         // Create the Scene.
         let mut scene = egui::containers::Scene::new()
-            .zoom_range(self.zoom_range.clone())
+            .zoom_range(self.zoom_range)
             .drag_pan_buttons(egui::containers::DragPanButtons::MIDDLE);
         if let Some(max_inner_size) = self.max_inner_size {
             scene = scene.max_inner_size(max_inner_size);
@@ -549,8 +549,8 @@ impl<'a> Show<'a> {
                 selection_rect,
                 select,
                 socket_press_released,
-                visited: &mut *visited,
-                layout: &mut *layout,
+                visited,
+                layout,
                 immutable,
             };
             content(&mut ctx, ui);
@@ -962,7 +962,7 @@ pub fn with_graph_memory<R>(
             .clone()
     });
     let gmem = gmem_arc.lock().expect("failed to lock graph temp memory");
-    f(&*gmem)
+    f(&gmem)
 }
 
 /// Checks if a node with the given ID is currently selected in the specified graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,11 +706,7 @@ pub struct EdgeInProgress {
 }
 
 impl EdgeInProgress {
-    pub fn bezier_cubic(&self) -> bezier::Cubic {
-        self.bezier_cubic_with_curvature(bezier::Cubic::DEFAULT_CURVATURE)
-    }
-
-    pub fn bezier_cubic_with_curvature(&self, curvature: f32) -> bezier::Cubic {
+    pub fn bezier_cubic(&self, curvature: f32) -> bezier::Cubic {
         let start = (self.start.pos, self.start.normal);
         let end_normal = self
             .end_socket
@@ -726,9 +722,9 @@ impl EdgeInProgress {
     /// If you require custom styling of the in-progress edge, use
     /// [`EdgeInProgress::bezier_cubic`] or the individual fields to paint it
     /// however you wish.
-    pub fn show(&self, ui: &egui::Ui) {
+    pub fn show(&self, ui: &egui::Ui, curvature: f32) {
         let dist_per_pt = crate::edge::Edge::DEFAULT_DISTANCE_PER_POINT;
-        let bezier = self.bezier_cubic();
+        let bezier = self.bezier_cubic(curvature);
         let pts = bezier.flatten(dist_per_pt).collect();
         let stroke = ui.visuals().widgets.active.fg_stroke;
         ui.painter().add(egui::Shape::line(pts, stroke));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,6 +707,10 @@ pub struct EdgeInProgress {
 
 impl EdgeInProgress {
     pub fn bezier_cubic(&self) -> bezier::Cubic {
+        self.bezier_cubic_with_curvature(bezier::Cubic::DEFAULT_CURVATURE)
+    }
+
+    pub fn bezier_cubic_with_curvature(&self, curvature: f32) -> bezier::Cubic {
         let start = (self.start.pos, self.start.normal);
         let end_normal = self
             .end_socket
@@ -714,7 +718,7 @@ impl EdgeInProgress {
             .map(|&(_, n)| n)
             .unwrap_or(-self.start.normal);
         let end = (self.end_pos, end_normal);
-        bezier::Cubic::from_edge_points(start, end)
+        bezier::Cubic::from_edge_points_with_curvature(start, end, curvature)
     }
 
     /// Short-hand for painting the in-progress edge with some reasonable defaults.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,6 +706,10 @@ pub struct EdgeInProgress {
 }
 
 impl EdgeInProgress {
+    /// Construct the bezier curve for this in-progress edge.
+    ///
+    /// `curvature` is a normalized `0.0..=1.0` value controlling how
+    /// pronounced the curve is. See [`bezier::Cubic::DEFAULT_CURVATURE`].
     pub fn bezier_cubic(&self, curvature: f32) -> bezier::Cubic {
         let start = (self.start.pos, self.start.normal);
         let end_normal = self
@@ -714,7 +718,7 @@ impl EdgeInProgress {
             .map(|&(_, n)| n)
             .unwrap_or(-self.start.normal);
         let end = (self.end_pos, end_normal);
-        bezier::Cubic::from_edge_points_with_curvature(start, end, curvature)
+        bezier::Cubic::from_edge_points(start, end, curvature)
     }
 
     /// Short-hand for painting the in-progress edge with some reasonable defaults.

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,6 +29,7 @@ pub struct Node {
     id: NodeId,
     inputs: usize,
     outputs: usize,
+    collapsed: bool,
     flow: egui::Direction,
     socket_radius: f32,
     socket_color: Option<egui::Color32>,
@@ -107,6 +108,7 @@ impl Node {
             socket_color: None,
             inputs: 0,
             outputs: 0,
+            collapsed: false,
             flow: egui::Direction::LeftToRight,
             socket_radius: 3.0,
             animation_time: 0.1,
@@ -128,6 +130,12 @@ impl Node {
 
     pub fn outputs(mut self, n: usize) -> Self {
         self.outputs = n;
+        self
+    }
+
+    /// Allow the node to shrink below the usual socket-spacing-driven minimum size.
+    pub fn collapsed(mut self, collapsed: bool) -> Self {
+        self.collapsed = collapsed;
         self
     }
 
@@ -247,7 +255,7 @@ impl Node {
         let win_corner_radius = ui.visuals().window_corner_radius.ne as f32;
         let socket_padding = win_corner_radius + min_interact_len * 0.5;
         let min_len = (max_sockets.max(1) - 1) as f32 * min_socket_gap + socket_padding * 2.0;
-        if max_sockets > 1 {
+        if max_sockets > 1 && !self.collapsed {
             match self.flow {
                 egui::Direction::LeftToRight | egui::Direction::RightToLeft => {
                     min_size.y = min_size.y.max(min_len);

--- a/src/node.rs
+++ b/src/node.rs
@@ -466,10 +466,8 @@ impl Node {
                             let index = c.index;
                             edge_event = Some(EdgeEvent::Ended { kind, index });
                         }
-                    } else if edge_event.is_none() {
-                        if self.id == r.node {
-                            edge_event = Some(EdgeEvent::Cancelled);
-                        }
+                    } else if edge_event.is_none() && self.id == r.node {
+                        edge_event = Some(EdgeEvent::Cancelled);
                     }
                 }
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -95,6 +95,8 @@ pub struct NodeCtx<'a> {
 }
 
 impl Node {
+    const COLLAPSED_SOCKET_GAP_FACTOR: f32 = 0.25;
+
     /// Begin instantiating a new node widget.
     pub fn new(id_src: impl Hash) -> Self {
         Self::from_id(NodeId::new(id_src))
@@ -133,7 +135,11 @@ impl Node {
         self
     }
 
-    /// Allow the node to shrink below the usual socket-spacing-driven minimum size.
+    /// Allow the node to shrink below the usual socket-spacing-driven minimum size
+    /// when there are two or more sockets.
+    ///
+    /// Collapsed nodes still preserve a small amount of socket separation so
+    /// multiple sockets do not fully overlap.
     pub fn collapsed(mut self, collapsed: bool) -> Self {
         self.collapsed = collapsed;
         self
@@ -254,8 +260,14 @@ impl Node {
         let min_socket_gap = min_interact_len + min_item_spacing;
         let win_corner_radius = ui.visuals().window_corner_radius.ne as f32;
         let socket_padding = win_corner_radius + min_interact_len * 0.5;
-        let min_len = (max_sockets.max(1) - 1) as f32 * min_socket_gap + socket_padding * 2.0;
-        if max_sockets > 1 && !self.collapsed {
+        if max_sockets > 1 {
+            let socket_gap_factor = if self.collapsed {
+                Self::COLLAPSED_SOCKET_GAP_FACTOR
+            } else {
+                1.0
+            };
+            let min_len = (max_sockets - 1) as f32 * min_socket_gap * socket_gap_factor
+                + socket_padding * 2.0;
             match self.flow {
                 egui::Direction::LeftToRight | egui::Direction::RightToLeft => {
                     min_size.y = min_size.y.max(min_len);

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -107,6 +107,7 @@ fn paint_semicircle(
 ///
 /// By rendering semicircles that only extend outward from the frame border, sockets avoid
 /// visual overlap with node frames regardless of sublayer ordering.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn show(
     ui: &mut egui::Ui,
     graph_id: egui::Id,


### PR DESCRIPTION
## What changed

This updates `egui_graph` with two related graph presentation controls:

- adds configurable edge curvature via the edge API and in-progress edge rendering
- adds collapsed node sizing so nodes can shrink below the normal socket-spacing-driven minimum size
- keeps a small reduced socket gap for collapsed nodes so sockets do not fully overlap, including in horizontal flow

## Why

The existing code always used the same bezier control distance for edges and always enforced full socket spacing for nodes. That made it difficult to tune graph readability and made collapsed nodes larger than desired.

This change makes curvature controllable with a normalized `0.0..=1.0` input while capping the effective control-point distance internally, and allows collapsed nodes to reduce their footprint without causing sockets to stack directly on top of each other.

## Impact

Callers can now:

- use `edge::Edge::curvature_factor(...)` to tune edge curvature
- use `EdgeInProgress::bezier_cubic_with_curvature(...)` for matching in-progress edge rendering
- use `node::Node::collapsed(true)` to opt into reduced minimum sizing for dense nodes

Existing callers that do not opt into the new builders keep the previous default curvature behaviour.

## Validation

- `cargo fmt`
- `cargo check`
- `cargo check --examples`
