### PR TITLE
ci: migrate release flow to release-plz with trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   cargo:
     permissions:
-      id-token: "write"
       contents: "read"
     runs-on: ubuntu-latest
     env:
@@ -34,29 +33,3 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - uses: Swatinem/rust-cache@v2
       - run: nix develop github:mitchmindtree/egui.nix -c cargo ${{ matrix.command }}
-
-  cargo-publish:
-    needs: cargo
-    permissions:
-      id-token: "write"
-      contents: "read"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - uses: nicknovitski/nix-develop@v1.2.1
-        with:
-          arguments: "github:mitchmindtree/egui.nix"
-      - uses: Swatinem/rust-cache@v2
-      - uses: katyo/publish-crates@v2
-        id: publish-crates
-        with:
-          registry-token: ${{ secrets.CRATESIO_TOKEN }}
-          dry-run: ${{ github.event_name != 'push' }}
-          ignore-unpublished-changes: true
-      - name: List published crates
-        if: ${{ steps.publish-crates.outputs.published != '' }}
-        run: |
-          LIST="${{ join(fromJSON(steps.publish-crates.outputs.published).*.name, ', ') }}"
-          echo "Published crates: $LIST"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,66 @@
+name: release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Publish the crate + create the tag/GitHub release when a release PR is merged.
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push tags, create releases
+      id-token: write # crates.io trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: Swatinem/rust-cache@v2
+      - id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+      # `nix develop` provides the egui build env (cargo, rustc, cc) that the
+      # publish verify build needs; the nested `nix shell` layers release-plz +
+      # cargo-semver-checks on top, pinned via egui.nix's nixpkgs input.
+      - run: |
+          nix develop github:mitchmindtree/egui.nix -c \
+            nix shell --inputs-from github:mitchmindtree/egui.nix \
+              nixpkgs#release-plz nixpkgs#cargo-semver-checks -c \
+            release-plz release
+        env:
+          # release-plz reads the git-forge token from GIT_TOKEN.
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Keep the version-bump + changelog PR up to date on every push to main.
+  release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: |
+          nix develop github:mitchmindtree/egui.nix -c \
+            nix shell --inputs-from github:mitchmindtree/egui.nix \
+              nixpkgs#release-plz nixpkgs#cargo-semver-checks -c \
+            release-plz release-pr
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.15.0"
 edition = "2021"
 description = "A general-purpose node graph widget for egui."
 license = "MIT"
-repository = "https://github.com/nannou-org/nannou.git"
+repository = "https://github.com/nannou-org/egui_graph"
 
 # Required for wgpu v0.10 feature resolution.
 resolver = "2"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+# Run cargo-semver-checks before each release so an API-breaking change forces
+# the correct version bump even when commit messages don't flag it (for a 0.x
+# crate: a breaking change bumps the minor, otherwise the patch).
+[workspace]
+semver_check = true


### PR DESCRIPTION
Replace the katyo/publish-crates job with a dedicated release-plz workflow that opens version-bump/changelog PRs and publishes to crates.io via OIDC trusted publishing, removing the need for the long-lived `CRATESIO_TOKEN` secret.

- add `.github/workflows/release-plz.yml` with release-pr and release jobs, both running inside the `egui.nix` devshell; `id-token: write` on the release job lets release-plz perform the trusted-publishing token exchange itself (no `CARGO_REGISTRY_TOKEN`)
- remove the cargo-publish job from `ci.yml` (now test-only) and drop its now-unused id-token permission
- fix the `Cargo.toml` repository field to point at `nannou-org/egui_graph`