### PR TITLE
Snap-align dragged nodes to other nodes' edges/centers

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -70,6 +70,7 @@ struct State {
     align_edges: bool,
     align_centers: bool,
     align_threshold: f32,
+    align_guides: bool,
 }
 
 #[derive(Default)]
@@ -146,6 +147,7 @@ impl App {
             align_edges: true,
             align_centers: false,
             align_threshold: 5.0,
+            align_guides: true,
         };
         let view = Default::default();
         App { view, state }
@@ -352,6 +354,7 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
             centers: state.align_centers,
         })
         .align_threshold(state.align_threshold)
+        .align_guides(state.align_guides)
         .show(view, ui, |ui, show| {
             show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
                 .edges(ui, |ectx, ui| {
@@ -660,6 +663,7 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
             ui.horizontal(|ui| {
                 ui.checkbox(&mut state.align_edges, "Edges");
                 ui.checkbox(&mut state.align_centers, "Centers");
+                ui.checkbox(&mut state.align_guides, "Guides");
             });
             ui.horizontal(|ui| {
                 ui.label("Threshold (px):");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -66,6 +66,10 @@ struct State {
     immutable: bool,
     snap_mode: SnapMode,
     grid_step: f32,
+    align: bool,
+    align_edges: bool,
+    align_centers: bool,
+    align_threshold: f32,
 }
 
 #[derive(Default)]
@@ -138,6 +142,10 @@ impl App {
             snap_mode: SnapMode::Point,
             // Matches the dot grid's previous default (style interact_size.y).
             grid_step: 18.0,
+            align: true,
+            align_edges: true,
+            align_centers: false,
+            align_threshold: 5.0,
         };
         let view = Default::default();
         App { view, state }
@@ -338,6 +346,12 @@ fn graph(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut State) {
             _ => 1.0,
         })
         .dot_grid_step(state.grid_step)
+        .align(state.align)
+        .align_targets(egui_graph::AlignTargets {
+            edges: state.align_edges,
+            centers: state.align_centers,
+        })
+        .align_threshold(state.align_threshold)
         .show(view, ui, |ui, show| {
             show.nodes(ui, |nctx, ui| nodes(nctx, ui, state))
                 .edges(ui, |ectx, ui| {
@@ -638,6 +652,18 @@ fn graph_config(ui: &mut egui::Ui, view: &mut egui_graph::View, state: &mut Stat
             ui.horizontal(|ui| {
                 ui.label("Step:");
                 ui.add(egui::DragValue::new(&mut state.grid_step).range(1.0..=200.0));
+            });
+
+            ui.add_space(8.0);
+            ui.label("ALIGN CONFIG");
+            ui.checkbox(&mut state.align, "Snap-align (hold Alt to disable)");
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut state.align_edges, "Edges");
+                ui.checkbox(&mut state.align_centers, "Centers");
+            });
+            ui.horizontal(|ui| {
+                ui.label("Threshold (px):");
+                ui.add(egui::DragValue::new(&mut state.align_threshold).range(0.0..=50.0));
             });
 
             ui.add_space(8.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,15 @@ pub struct Graph {
     snap: Option<Snap>,
     /// The granularity (in graph-space units) used when snapping.
     snap_step: f32,
+    /// Whether dragged nodes snap to align their edges/centers with other nodes.
+    align: bool,
+    /// Which node features are considered when aligning.
+    align_targets: AlignTargets,
+    /// The screen-pixel distance within which an alignment snaps, or `None` to
+    /// derive it from the style's `interact_radius`.
+    align_threshold: Option<f32>,
+    /// A held modifier that temporarily disables alignment during a drag.
+    align_disable_modifier: egui::Modifiers,
 }
 
 /// How the view responds when the available viewport size changes
@@ -76,6 +85,26 @@ pub enum Snap {
     Round,
     /// Round down (toward negative infinity) to a multiple of the step.
     Floor,
+}
+
+/// Which node features are considered when snap-aligning a dragged selection to
+/// other nodes. See [`Graph::align`] and [`Graph::align_targets`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AlignTargets {
+    /// Align the left/right/top/bottom edges.
+    pub edges: bool,
+    /// Align the horizontal and vertical centers.
+    pub centers: bool,
+    // Follow-up: a `sockets` field for socket-to-socket alignment.
+}
+
+impl Default for AlignTargets {
+    fn default() -> Self {
+        AlignTargets {
+            edges: true,
+            centers: false,
+        }
+    }
 }
 
 /// State related to the graph UI.
@@ -280,6 +309,18 @@ impl Graph {
     pub const DEFAULT_SNAP: Option<Snap> = Some(Snap::Round);
     /// The default snapping granularity, in graph-space units.
     pub const DEFAULT_SNAP_STEP: f32 = 1.0;
+    /// Snap-align is enabled by default.
+    pub const DEFAULT_ALIGN: bool = true;
+    /// By default, alignment considers edges only (centers can feel busy).
+    pub const DEFAULT_ALIGN_TARGETS: AlignTargets = AlignTargets {
+        edges: true,
+        centers: false,
+    };
+    /// The default alignment threshold. `None` derives it from the style's
+    /// `interact_radius`.
+    pub const DEFAULT_ALIGN_THRESHOLD: Option<f32> = None;
+    /// The default modifier held to temporarily disable alignment.
+    pub const DEFAULT_ALIGN_DISABLE_MODIFIER: egui::Modifiers = egui::Modifiers::ALT;
 
     /// Begin building the new graph widget.
     pub fn new(id_src: impl Hash) -> Self {
@@ -301,6 +342,10 @@ impl Graph {
             immutable: false,
             snap: Self::DEFAULT_SNAP,
             snap_step: Self::DEFAULT_SNAP_STEP,
+            align: Self::DEFAULT_ALIGN,
+            align_targets: Self::DEFAULT_ALIGN_TARGETS,
+            align_threshold: Self::DEFAULT_ALIGN_THRESHOLD,
+            align_disable_modifier: Self::DEFAULT_ALIGN_DISABLE_MODIFIER,
         }
     }
 
@@ -413,6 +458,55 @@ impl Graph {
         self
     }
 
+    /// Whether dragged nodes snap to align their edges/centers with other nodes.
+    ///
+    /// When a dragged node (or selection) comes within
+    /// [`align_threshold`](Self::align_threshold) of another node, it snaps
+    /// along that axis so the features in [`align_targets`](Self::align_targets)
+    /// line up. Each axis is decided independently and takes priority over
+    /// [`snap`](Self::snap): an axis that finds an alignment uses it, while an
+    /// axis that doesn't falls back to the snap setting. Hold
+    /// [`align_disable_modifier`](Self::align_disable_modifier) to suppress it.
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN`] (`true`).
+    pub fn align(mut self, align: bool) -> Self {
+        self.align = align;
+        self
+    }
+
+    /// Which node features ([`AlignTargets`]) are considered when aligning.
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN_TARGETS`] (edges and centers).
+    pub fn align_targets(mut self, targets: AlignTargets) -> Self {
+        self.align_targets = targets;
+        self
+    }
+
+    /// The distance (in *screen* pixels) within which an edge or center snaps
+    /// to align.
+    ///
+    /// The value is converted to graph units using the live zoom each frame, so
+    /// the snap "feel" stays constant in pixels across zoom levels. When unset
+    /// (the default), the threshold is derived from the style's
+    /// `interact_radius`.
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN_THRESHOLD`] (`None`).
+    pub fn align_threshold(mut self, threshold: f32) -> Self {
+        self.align_threshold = Some(threshold);
+        self
+    }
+
+    /// The keyboard modifier held to temporarily disable alignment during a
+    /// drag (the axis then falls back to the [`snap`](Self::snap) setting).
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN_DISABLE_MODIFIER`] ([`Modifiers::ALT`]).
+    ///
+    /// [`Modifiers::ALT`]: egui::Modifiers::ALT
+    pub fn align_disable_modifier(mut self, modifier: egui::Modifiers) -> Self {
+        self.align_disable_modifier = modifier;
+        self
+    }
+
     /// Begin showing the Graph.
     ///
     /// Returns a [`GraphResponse`] containing the user's return value,
@@ -521,28 +615,98 @@ impl Graph {
                 );
 
                 // Move all selected nodes by a single delta (skip when
-                // immutable). When snapping, anchor on the pressed node: snap
-                // *its* target to the grid and translate the whole selection by
-                // the same offset. This keeps the group rigid (preserving its
-                // relative layout) instead of snapping each node independently,
-                // which distorts the cluster. The per-node snap below skips the
-                // dragged nodes for the same reason.
+                // immutable), keeping the group rigid (preserving its relative
+                // layout) by translating every node by the same offset rather
+                // than snapping each independently. Per axis, snap-align wins if
+                // a within-threshold edge/center is found; otherwise the axis
+                // falls back to snapping the pressed node's target to the grid.
+                // The per-node snap below skips the dragged nodes for the same
+                // (rigidity) reason.
                 if !self.immutable && interaction.drag_nodes_delta != egui::Vec2::ZERO {
                     if let Some(pressed) = gmem.pressed.as_ref() {
                         if let PressAction::DragNodes {
                             node: Some(pressed_node),
                         } = &pressed.action
                         {
-                            let delta = match self.snap {
-                                Some(snap) => match layout.get(&pressed_node.id) {
-                                    Some(&current) => {
-                                        let target = current + interaction.drag_nodes_delta;
-                                        snap_pos(snap, self.snap_step, target) - current
-                                    }
-                                    None => interaction.drag_nodes_delta,
-                                },
-                                None => interaction.drag_nodes_delta,
+                            let raw = interaction.drag_nodes_delta;
+
+                            // The alignment threshold is configured in screen
+                            // pixels; convert it to graph units via the live
+                            // zoom so the snap zone stays a constant on-screen
+                            // size. Guard a missing/degenerate transform.
+                            let scale = ui
+                                .ctx()
+                                .layer_transform_to_global(ui.layer_id())
+                                .map(|t| t.scaling)
+                                .filter(|s| s.is_finite() && *s > 0.0)
+                                .unwrap_or(1.0);
+                            let modifiers = ui.input(|i| i.modifiers);
+                            let align_on =
+                                self.align && !modifiers.contains(self.align_disable_modifier);
+                            let threshold_px = self
+                                .align_threshold
+                                .filter(|t| t.is_finite() && *t > 0.0)
+                                .unwrap_or_else(|| ui.style().interaction.interact_radius);
+                            let threshold = threshold_px / scale;
+
+                            // Per-axis alignment of the dragged group's bounding
+                            // box to the surrounding (non-selected) nodes.
+                            let (adj_x, adj_y) = if align_on {
+                                let selected_rects: Vec<egui::Rect> = gmem
+                                    .selection
+                                    .nodes
+                                    .iter()
+                                    .filter_map(|id| {
+                                        let pos = *layout.get(id)?;
+                                        let size = *gmem.node_sizes.get(id)?;
+                                        Some(egui::Rect::from_min_size(pos, size))
+                                    })
+                                    .collect();
+                                // Sort references by id for deterministic
+                                // tie-breaks (HashMap order is unstable).
+                                let mut refs: Vec<(NodeId, egui::Rect)> = layout
+                                    .iter()
+                                    .filter(|(id, _)| !gmem.selection.nodes.contains(id))
+                                    .filter_map(|(id, &pos)| {
+                                        let size = *gmem.node_sizes.get(id)?;
+                                        Some((*id, egui::Rect::from_min_size(pos, size)))
+                                    })
+                                    .collect();
+                                refs.sort_by_key(|(id, _)| *id);
+                                let reference_rects: Vec<egui::Rect> =
+                                    refs.into_iter().map(|(_, r)| r).collect();
+                                align_adjust(
+                                    self.align_targets,
+                                    &selected_rects,
+                                    &reference_rects,
+                                    raw,
+                                    threshold,
+                                )
+                            } else {
+                                (None, None)
                             };
+
+                            // Combine per axis: alignment, else snap fallback of
+                            // the anchor's target (equivalent to the previous
+                            // `snap_pos(..) - current` math, applied per axis).
+                            let anchor = layout.get(&pressed_node.id).copied();
+                            let snap = self.snap;
+                            let snap_step = self.snap_step;
+                            let axis =
+                                |adj: Option<f32>, raw_a: f32, anchor_a: Option<f32>| match adj {
+                                    Some(a) => raw_a + a,
+                                    None => match (snap, anchor_a) {
+                                        (Some(snap), Some(c)) => {
+                                            snap_f32(snap, snap_step, c + raw_a) - c
+                                        }
+                                        _ => raw_a,
+                                    },
+                                };
+                            let delta = egui::vec2(
+                                axis(adj_x, raw.x, anchor.map(|p| p.x)),
+                                axis(adj_y, raw.y, anchor.map(|p| p.y)),
+                            );
+
                             for &n_id in &gmem.selection.nodes {
                                 if let Some(pos) = layout.get_mut(&n_id) {
                                     *pos += delta;
@@ -1248,6 +1412,69 @@ pub fn snap_vec(snap: Snap, step: f32, v: egui::Vec2) -> egui::Vec2 {
     egui::vec2(snap_f32(snap, step, v.x), snap_f32(snap, step, v.y))
 }
 
+/// The per-axis adjustment to add to a drag delta so the dragged group snaps to
+/// align with surrounding nodes.
+///
+/// The dragged group's bounding box (the union of `selected_rects`) is moved by
+/// `raw_delta`, then each axis is matched against the `reference_rects`: edges
+/// are compared with edges and centers with centers (per `targets`), and the
+/// closest candidate within `threshold` (in graph units) wins. Returns `None`
+/// on an axis with no candidate within range.
+fn align_adjust(
+    targets: AlignTargets,
+    selected_rects: &[egui::Rect],
+    reference_rects: &[egui::Rect],
+    raw_delta: egui::Vec2,
+    threshold: f32,
+) -> (Option<f32>, Option<f32>) {
+    if selected_rects.is_empty()
+        || reference_rects.is_empty()
+        || !threshold.is_finite()
+        || threshold <= 0.0
+        || !(targets.edges || targets.centers)
+    {
+        return (None, None);
+    }
+
+    // The dragged group's bounding box at the target (post-delta) position.
+    let mut bbox = selected_rects[0];
+    for r in &selected_rects[1..] {
+        bbox = bbox.union(*r);
+    }
+    let target = bbox.translate(raw_delta);
+
+    // Keep the smallest within-threshold adjustment (`reference - dragged`) for
+    // an axis. `dragged + adjust == reference`, so the edges/centers coincide.
+    let consider = |best: &mut Option<f32>, dragged: f32, reference: f32| {
+        let adjust = reference - dragged;
+        if adjust.abs() <= threshold && best.map_or(true, |b| adjust.abs() < b.abs()) {
+            *best = Some(adjust);
+        }
+    };
+
+    let mut adj_x = None;
+    let mut adj_y = None;
+    for r in reference_rects {
+        if targets.edges {
+            // Any dragged x-edge may align to any reference x-edge (covers
+            // both same-edge alignment and edge-to-edge "touching").
+            consider(&mut adj_x, target.min.x, r.min.x);
+            consider(&mut adj_x, target.min.x, r.max.x);
+            consider(&mut adj_x, target.max.x, r.min.x);
+            consider(&mut adj_x, target.max.x, r.max.x);
+            consider(&mut adj_y, target.min.y, r.min.y);
+            consider(&mut adj_y, target.min.y, r.max.y);
+            consider(&mut adj_y, target.max.y, r.min.y);
+            consider(&mut adj_y, target.max.y, r.max.y);
+        }
+        if targets.centers {
+            consider(&mut adj_x, target.center().x, r.center().x);
+            consider(&mut adj_y, target.center().y, r.center().y);
+        }
+    }
+    (adj_x, adj_y)
+}
+
 /// Short-hand for retrieving access to the graph's temporary memory from the `Ui`.
 fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
     ui.ctx().data_mut(|d| {
@@ -1258,7 +1485,9 @@ fn memory(ui: &egui::Ui, graph_id: egui::Id) -> Arc<Mutex<GraphTempMemory>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{dot_grid_step, maintain_zoom_scene_rect, snap_f32, Snap};
+    use super::{
+        align_adjust, dot_grid_step, maintain_zoom_scene_rect, snap_f32, AlignTargets, Snap,
+    };
     use egui::{Rangef, Rect, Vec2};
 
     /// The scale egui's `Scene` would apply when fitting `scene_rect` into a
@@ -1378,5 +1607,152 @@ mod tests {
         // Non-finite input passes straight through.
         assert!(snap_f32(Snap::Round, 1.0, f32::INFINITY).is_infinite());
         assert!(snap_f32(Snap::Round, 1.0, f32::NAN).is_nan());
+    }
+
+    fn rect(x: f32, y: f32, w: f32, h: f32) -> Rect {
+        Rect::from_min_size(egui::pos2(x, y), egui::vec2(w, h))
+    }
+
+    const EDGES: AlignTargets = AlignTargets {
+        edges: true,
+        centers: false,
+    };
+    const CENTERS: AlignTargets = AlignTargets {
+        edges: false,
+        centers: true,
+    };
+
+    #[test]
+    fn align_no_candidates() {
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        // No reference nodes.
+        assert_eq!(
+            align_adjust(EDGES, &sel, &[], Vec2::ZERO, 5.0),
+            (None, None)
+        );
+        // Empty selection.
+        let refs = [rect(0.0, 0.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &[], &refs, Vec2::ZERO, 5.0),
+            (None, None)
+        );
+    }
+
+    #[test]
+    fn align_edge_within_and_beyond_threshold() {
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        // Left edge 2 away on x, far on y -> aligns x only.
+        let near = [rect(2.0, 100.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &near, Vec2::ZERO, 5.0),
+            (Some(2.0), None)
+        );
+        // All edges beyond threshold -> no adjustment.
+        let far = [rect(20.0, 200.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &far, Vec2::ZERO, 5.0),
+            (None, None)
+        );
+    }
+
+    #[test]
+    fn align_touching_edge() {
+        // Dragged right edge (10) snaps to reference left edge (12).
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        let refs = [rect(12.0, 100.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
+            (Some(2.0), None)
+        );
+    }
+
+    #[test]
+    fn align_closest_candidate_wins() {
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        // Nearer left edge (2) wins over the farther one (4).
+        let refs = [rect(4.0, 100.0, 10.0, 10.0), rect(2.0, 200.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0,
+            Some(2.0)
+        );
+    }
+
+    #[test]
+    fn align_axes_independent() {
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        let x_only = [rect(3.0, 200.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &x_only, Vec2::ZERO, 5.0),
+            (Some(3.0), None)
+        );
+        let y_only = [rect(200.0, 3.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &y_only, Vec2::ZERO, 5.0),
+            (None, Some(3.0))
+        );
+    }
+
+    #[test]
+    fn align_centers_only() {
+        // Wide dragged vs narrow reference: centers coincide (0), edges out of range.
+        let sel = [rect(0.0, 0.0, 20.0, 10.0)]; // center x = 10
+        let refs = [rect(6.0, 100.0, 8.0, 10.0)]; // center x = 10, edges 6/14
+        assert_eq!(
+            align_adjust(CENTERS, &sel, &refs, Vec2::ZERO, 5.0),
+            (Some(0.0), None)
+        );
+        // Edges-only finds nothing in the same arrangement.
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
+            (None, None)
+        );
+    }
+
+    #[test]
+    fn align_uses_group_bbox_union() {
+        // A 2-node group; only the union's far edge (30) is near the reference,
+        // so a single-node bbox (right edge 10) would miss it.
+        let sel = [rect(0.0, 0.0, 10.0, 10.0), rect(20.0, 0.0, 10.0, 10.0)];
+        let refs = [rect(28.0, 200.0, 10.0, 10.0)]; // left edge 28
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
+            (Some(-2.0), None)
+        );
+    }
+
+    #[test]
+    fn align_applies_raw_delta() {
+        // After moving +100 on x, the dragged left edge (100) aligns to 102.
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        let refs = [rect(102.0, 100.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, egui::vec2(100.0, 0.0), 5.0),
+            (Some(2.0), None)
+        );
+    }
+
+    #[test]
+    fn align_threshold_guards() {
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        let refs = [rect(0.0, 0.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 0.0),
+            (None, None)
+        );
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, f32::NAN),
+            (None, None)
+        );
+    }
+
+    #[test]
+    fn align_deterministic_tie_break() {
+        // Two equidistant references; with a fixed order the first one wins.
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)];
+        let refs = [rect(-2.0, 100.0, 10.0, 10.0), rect(2.0, 200.0, 10.0, 10.0)];
+        assert_eq!(
+            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0,
+            Some(-2.0)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,12 @@ pub struct Graph {
     align_threshold: Option<f32>,
     /// A held modifier that temporarily disables alignment during a drag.
     align_disable_modifier: egui::Modifiers,
+    /// Whether to draw a subtle guide line along an edge/center that is
+    /// currently aligning during a drag.
+    align_guides: bool,
+    /// The stroke for alignment guide lines (width in screen pixels), or `None`
+    /// to derive a subtle default from the style.
+    align_guide_stroke: Option<egui::Stroke>,
 }
 
 /// How the view responds when the available viewport size changes
@@ -321,6 +327,10 @@ impl Graph {
     pub const DEFAULT_ALIGN_THRESHOLD: Option<f32> = None;
     /// The default modifier held to temporarily disable alignment.
     pub const DEFAULT_ALIGN_DISABLE_MODIFIER: egui::Modifiers = egui::Modifiers::ALT;
+    /// Subtle alignment guide lines are drawn by default.
+    pub const DEFAULT_ALIGN_GUIDES: bool = true;
+    /// The default guide stroke. `None` derives a subtle stroke from the style.
+    pub const DEFAULT_ALIGN_GUIDE_STROKE: Option<egui::Stroke> = None;
 
     /// Begin building the new graph widget.
     pub fn new(id_src: impl Hash) -> Self {
@@ -346,6 +356,8 @@ impl Graph {
             align_targets: Self::DEFAULT_ALIGN_TARGETS,
             align_threshold: Self::DEFAULT_ALIGN_THRESHOLD,
             align_disable_modifier: Self::DEFAULT_ALIGN_DISABLE_MODIFIER,
+            align_guides: Self::DEFAULT_ALIGN_GUIDES,
+            align_guide_stroke: Self::DEFAULT_ALIGN_GUIDE_STROKE,
         }
     }
 
@@ -507,6 +519,28 @@ impl Graph {
         self
     }
 
+    /// Whether to draw a subtle guide line along an edge/center that is
+    /// currently aligning during a drag.
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN_GUIDES`] (`true`).
+    pub fn align_guides(mut self, guides: bool) -> Self {
+        self.align_guides = guides;
+        self
+    }
+
+    /// The stroke used for alignment guide lines.
+    ///
+    /// The width is interpreted in *screen* pixels (converted to graph units via
+    /// the live zoom, so it stays a constant on-screen thickness). When unset
+    /// (the default), a subtle stroke is derived from the style's selection
+    /// colour.
+    ///
+    /// Default: [`Self::DEFAULT_ALIGN_GUIDE_STROKE`] (`None`).
+    pub fn align_guide_stroke(mut self, stroke: egui::Stroke) -> Self {
+        self.align_guide_stroke = Some(stroke);
+        self
+    }
+
     /// Begin showing the Graph.
     ///
     /// Returns a [`GraphResponse`] containing the user's return value,
@@ -563,6 +597,8 @@ impl Graph {
             let mut select = false;
             let mut closest_socket = None;
             let mut socket_press_released = None;
+            // Alignment guide lines collected during a drag, as (is_x_axis, line).
+            let mut guide_lines: Vec<(bool, AlignLine)> = Vec::new();
 
             // Check for interactions with the scene area.
             let scene_response = ui.response();
@@ -651,7 +687,7 @@ impl Graph {
 
                             // Per-axis alignment of the dragged group's bounding
                             // box to the surrounding (non-selected) nodes.
-                            let (adj_x, adj_y) = if align_on {
+                            let (line_x, line_y) = if align_on {
                                 let selected_rects: Vec<egui::Rect> = gmem
                                     .selection
                                     .nodes
@@ -693,19 +729,28 @@ impl Graph {
                             let snap = self.snap;
                             let snap_step = self.snap_step;
                             let axis =
-                                |adj: Option<f32>, raw_a: f32, anchor_a: Option<f32>| match adj {
-                                    Some(a) => raw_a + a,
-                                    None => match (snap, anchor_a) {
-                                        (Some(snap), Some(c)) => {
-                                            snap_f32(snap, snap_step, c + raw_a) - c
-                                        }
-                                        _ => raw_a,
-                                    },
+                                |line: Option<AlignLine>, raw_a: f32, anchor_a: Option<f32>| {
+                                    match line {
+                                        Some(l) => raw_a + l.adjust,
+                                        None => match (snap, anchor_a) {
+                                            (Some(snap), Some(c)) => {
+                                                snap_f32(snap, snap_step, c + raw_a) - c
+                                            }
+                                            _ => raw_a,
+                                        },
+                                    }
                                 };
                             let delta = egui::vec2(
-                                axis(adj_x, raw.x, anchor.map(|p| p.x)),
-                                axis(adj_y, raw.y, anchor.map(|p| p.y)),
+                                axis(line_x, raw.x, anchor.map(|p| p.x)),
+                                axis(line_y, raw.y, anchor.map(|p| p.y)),
                             );
+
+                            // Record the aligning edges so a subtle guide can be
+                            // drawn along them once the nodes are laid out.
+                            if self.align_guides {
+                                guide_lines.extend(line_x.map(|l| (true, l)));
+                                guide_lines.extend(line_y.map(|l| (false, l)));
+                            }
 
                             for &n_id in &gmem.selection.nodes {
                                 if let Some(pos) = layout.get_mut(&n_id) {
@@ -753,6 +798,11 @@ impl Graph {
             // Paint some subtle dots to check camera movement.
             if self.dot_grid {
                 paint_dot_grid(visible_rect, self.dot_grid_step, ui);
+            }
+
+            // Paint subtle guide lines along edges/centers aligning this frame.
+            if !guide_lines.is_empty() {
+                paint_align_guides(&guide_lines, self.align_guide_stroke, ui);
             }
 
             // Draw the selection area if there is one.
@@ -1412,8 +1462,21 @@ pub fn snap_vec(snap: Snap, step: f32, v: egui::Vec2) -> egui::Vec2 {
     egui::vec2(snap_f32(snap, step, v.x), snap_f32(snap, step, v.y))
 }
 
-/// The per-axis adjustment to add to a drag delta so the dragged group snaps to
-/// align with surrounding nodes.
+/// A matched alignment on one axis: how far to nudge the drag delta, and where
+/// (and over what perpendicular span) to draw the guide line.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct AlignLine {
+    /// The amount to add to the raw drag delta on this axis so the features
+    /// coincide.
+    adjust: f32,
+    /// The aligned coordinate on this axis (where the guide line sits).
+    pos: f32,
+    /// The perpendicular extent the guide line spans (covering both the dragged
+    /// group and the matched reference node).
+    span: egui::Rangef,
+}
+
+/// Per-axis snap-alignment of a dragged group to the surrounding nodes.
 ///
 /// The dragged group's bounding box (the union of `selected_rects`) is moved by
 /// `raw_delta`, then each axis is matched against the `reference_rects`: edges
@@ -1426,7 +1489,7 @@ fn align_adjust(
     reference_rects: &[egui::Rect],
     raw_delta: egui::Vec2,
     threshold: f32,
-) -> (Option<f32>, Option<f32>) {
+) -> (Option<AlignLine>, Option<AlignLine>) {
     if selected_rects.is_empty()
         || reference_rects.is_empty()
         || !threshold.is_finite()
@@ -1443,36 +1506,83 @@ fn align_adjust(
     }
     let target = bbox.translate(raw_delta);
 
-    // Keep the smallest within-threshold adjustment (`reference - dragged`) for
-    // an axis. `dragged + adjust == reference`, so the edges/centers coincide.
-    let consider = |best: &mut Option<f32>, dragged: f32, reference: f32| {
+    // Keep the smallest within-threshold match (`reference - dragged`) for an
+    // axis, tracking the reference rect so the guide can span both nodes.
+    type Best = Option<(f32, f32, egui::Rect)>; // (adjust, pos, reference rect)
+    let consider = |best: &mut Best, dragged: f32, reference: f32, r: egui::Rect| {
         let adjust = reference - dragged;
-        if adjust.abs() <= threshold && best.map_or(true, |b| adjust.abs() < b.abs()) {
-            *best = Some(adjust);
+        if adjust.abs() <= threshold && best.map_or(true, |(b, _, _)| adjust.abs() < b.abs()) {
+            *best = Some((adjust, reference, r));
         }
     };
 
-    let mut adj_x = None;
-    let mut adj_y = None;
-    for r in reference_rects {
+    let mut best_x: Best = None;
+    let mut best_y: Best = None;
+    for &r in reference_rects {
         if targets.edges {
             // Any dragged x-edge may align to any reference x-edge (covers
             // both same-edge alignment and edge-to-edge "touching").
-            consider(&mut adj_x, target.min.x, r.min.x);
-            consider(&mut adj_x, target.min.x, r.max.x);
-            consider(&mut adj_x, target.max.x, r.min.x);
-            consider(&mut adj_x, target.max.x, r.max.x);
-            consider(&mut adj_y, target.min.y, r.min.y);
-            consider(&mut adj_y, target.min.y, r.max.y);
-            consider(&mut adj_y, target.max.y, r.min.y);
-            consider(&mut adj_y, target.max.y, r.max.y);
+            consider(&mut best_x, target.min.x, r.min.x, r);
+            consider(&mut best_x, target.min.x, r.max.x, r);
+            consider(&mut best_x, target.max.x, r.min.x, r);
+            consider(&mut best_x, target.max.x, r.max.x, r);
+            consider(&mut best_y, target.min.y, r.min.y, r);
+            consider(&mut best_y, target.min.y, r.max.y, r);
+            consider(&mut best_y, target.max.y, r.min.y, r);
+            consider(&mut best_y, target.max.y, r.max.y, r);
         }
         if targets.centers {
-            consider(&mut adj_x, target.center().x, r.center().x);
-            consider(&mut adj_y, target.center().y, r.center().y);
+            consider(&mut best_x, target.center().x, r.center().x, r);
+            consider(&mut best_y, target.center().y, r.center().y, r);
         }
     }
-    (adj_x, adj_y)
+
+    // A vertical guide (x-axis match) spans the y extent of both nodes; a
+    // horizontal guide spans their x extent.
+    let line_x = best_x.map(|(adjust, pos, r)| AlignLine {
+        adjust,
+        pos,
+        span: egui::Rangef::new(target.min.y.min(r.min.y), target.max.y.max(r.max.y)),
+    });
+    let line_y = best_y.map(|(adjust, pos, r)| AlignLine {
+        adjust,
+        pos,
+        span: egui::Rangef::new(target.min.x.min(r.min.x), target.max.x.max(r.max.x)),
+    });
+    (line_x, line_y)
+}
+
+/// Paint the subtle alignment guide lines collected during a drag. Each entry
+/// is `(is_x_axis, line)`: an x-axis match draws a vertical line, a y-axis match
+/// a horizontal one. Drawn in graph space; the stroke width is treated as screen
+/// pixels and scaled so the line stays a constant on-screen thickness.
+fn paint_align_guides(
+    lines: &[(bool, AlignLine)],
+    guide_stroke: Option<egui::Stroke>,
+    ui: &egui::Ui,
+) {
+    let scale = ui
+        .ctx()
+        .layer_transform_to_global(ui.layer_id())
+        .map(|t| t.scaling)
+        .filter(|s| s.is_finite() && *s > 0.0)
+        .unwrap_or(1.0);
+    // Default to a faint 1px line in the selection colour at reduced opacity.
+    let base = guide_stroke.unwrap_or_else(|| {
+        let color = ui.visuals().selection.stroke.color.gamma_multiply(0.5);
+        egui::Stroke::new(1.0, color)
+    });
+    let stroke = egui::Stroke::new(base.width / scale, base.color);
+    let painter = ui.painter();
+    for &(is_x_axis, line) in lines {
+        if is_x_axis {
+            // Vertical line at x = pos, spanning the y extent.
+            painter.vline(line.pos, line.span, stroke);
+        } else {
+            // Horizontal line at y = pos, spanning the x extent.
+            painter.hline(line.span, line.pos, stroke);
+        }
+    }
 }
 
 /// Short-hand for retrieving access to the graph's temporary memory from the `Ui`.
@@ -1622,20 +1732,26 @@ mod tests {
         centers: true,
     };
 
+    /// `align_adjust` reduced to just the per-axis adjustments, for brevity.
+    fn align(
+        targets: AlignTargets,
+        sel: &[Rect],
+        refs: &[Rect],
+        raw: Vec2,
+        threshold: f32,
+    ) -> (Option<f32>, Option<f32>) {
+        let (x, y) = align_adjust(targets, sel, refs, raw, threshold);
+        (x.map(|l| l.adjust), y.map(|l| l.adjust))
+    }
+
     #[test]
     fn align_no_candidates() {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         // No reference nodes.
-        assert_eq!(
-            align_adjust(EDGES, &sel, &[], Vec2::ZERO, 5.0),
-            (None, None)
-        );
+        assert_eq!(align(EDGES, &sel, &[], Vec2::ZERO, 5.0), (None, None));
         // Empty selection.
         let refs = [rect(0.0, 0.0, 10.0, 10.0)];
-        assert_eq!(
-            align_adjust(EDGES, &[], &refs, Vec2::ZERO, 5.0),
-            (None, None)
-        );
+        assert_eq!(align(EDGES, &[], &refs, Vec2::ZERO, 5.0), (None, None));
     }
 
     #[test]
@@ -1644,15 +1760,12 @@ mod tests {
         // Left edge 2 away on x, far on y -> aligns x only.
         let near = [rect(2.0, 100.0, 10.0, 10.0)];
         assert_eq!(
-            align_adjust(EDGES, &sel, &near, Vec2::ZERO, 5.0),
+            align(EDGES, &sel, &near, Vec2::ZERO, 5.0),
             (Some(2.0), None)
         );
         // All edges beyond threshold -> no adjustment.
         let far = [rect(20.0, 200.0, 10.0, 10.0)];
-        assert_eq!(
-            align_adjust(EDGES, &sel, &far, Vec2::ZERO, 5.0),
-            (None, None)
-        );
+        assert_eq!(align(EDGES, &sel, &far, Vec2::ZERO, 5.0), (None, None));
     }
 
     #[test]
@@ -1661,7 +1774,7 @@ mod tests {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         let refs = [rect(12.0, 100.0, 10.0, 10.0)];
         assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
+            align(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
             (Some(2.0), None)
         );
     }
@@ -1671,10 +1784,7 @@ mod tests {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         // Nearer left edge (2) wins over the farther one (4).
         let refs = [rect(4.0, 100.0, 10.0, 10.0), rect(2.0, 200.0, 10.0, 10.0)];
-        assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0,
-            Some(2.0)
-        );
+        assert_eq!(align(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0, Some(2.0));
     }
 
     #[test]
@@ -1682,12 +1792,12 @@ mod tests {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         let x_only = [rect(3.0, 200.0, 10.0, 10.0)];
         assert_eq!(
-            align_adjust(EDGES, &sel, &x_only, Vec2::ZERO, 5.0),
+            align(EDGES, &sel, &x_only, Vec2::ZERO, 5.0),
             (Some(3.0), None)
         );
         let y_only = [rect(200.0, 3.0, 10.0, 10.0)];
         assert_eq!(
-            align_adjust(EDGES, &sel, &y_only, Vec2::ZERO, 5.0),
+            align(EDGES, &sel, &y_only, Vec2::ZERO, 5.0),
             (None, Some(3.0))
         );
     }
@@ -1698,14 +1808,11 @@ mod tests {
         let sel = [rect(0.0, 0.0, 20.0, 10.0)]; // center x = 10
         let refs = [rect(6.0, 100.0, 8.0, 10.0)]; // center x = 10, edges 6/14
         assert_eq!(
-            align_adjust(CENTERS, &sel, &refs, Vec2::ZERO, 5.0),
+            align(CENTERS, &sel, &refs, Vec2::ZERO, 5.0),
             (Some(0.0), None)
         );
         // Edges-only finds nothing in the same arrangement.
-        assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
-            (None, None)
-        );
+        assert_eq!(align(EDGES, &sel, &refs, Vec2::ZERO, 5.0), (None, None));
     }
 
     #[test]
@@ -1715,7 +1822,7 @@ mod tests {
         let sel = [rect(0.0, 0.0, 10.0, 10.0), rect(20.0, 0.0, 10.0, 10.0)];
         let refs = [rect(28.0, 200.0, 10.0, 10.0)]; // left edge 28
         assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
+            align(EDGES, &sel, &refs, Vec2::ZERO, 5.0),
             (Some(-2.0), None)
         );
     }
@@ -1726,7 +1833,7 @@ mod tests {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         let refs = [rect(102.0, 100.0, 10.0, 10.0)];
         assert_eq!(
-            align_adjust(EDGES, &sel, &refs, egui::vec2(100.0, 0.0), 5.0),
+            align(EDGES, &sel, &refs, egui::vec2(100.0, 0.0), 5.0),
             (Some(2.0), None)
         );
     }
@@ -1735,12 +1842,9 @@ mod tests {
     fn align_threshold_guards() {
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         let refs = [rect(0.0, 0.0, 10.0, 10.0)];
+        assert_eq!(align(EDGES, &sel, &refs, Vec2::ZERO, 0.0), (None, None));
         assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 0.0),
-            (None, None)
-        );
-        assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, f32::NAN),
+            align(EDGES, &sel, &refs, Vec2::ZERO, f32::NAN),
             (None, None)
         );
     }
@@ -1750,9 +1854,20 @@ mod tests {
         // Two equidistant references; with a fixed order the first one wins.
         let sel = [rect(0.0, 0.0, 10.0, 10.0)];
         let refs = [rect(-2.0, 100.0, 10.0, 10.0), rect(2.0, 200.0, 10.0, 10.0)];
-        assert_eq!(
-            align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0,
-            Some(-2.0)
-        );
+        assert_eq!(align(EDGES, &sel, &refs, Vec2::ZERO, 5.0).0, Some(-2.0));
+    }
+
+    #[test]
+    fn align_line_geometry() {
+        // Left edges align (adjust +2); the vertical guide sits at the aligned
+        // coordinate and spans both nodes' y extents.
+        let sel = [rect(0.0, 0.0, 10.0, 10.0)]; // y: 0..10
+        let refs = [rect(2.0, 20.0, 10.0, 8.0)]; // left edge 2, y: 20..28
+        let (x, y) = align_adjust(EDGES, &sel, &refs, Vec2::ZERO, 5.0);
+        let x = x.expect("x axis should align");
+        assert_eq!(x.adjust, 2.0);
+        assert_eq!(x.pos, 2.0); // the reference left edge
+        assert_eq!(x.span, Rangef::new(0.0, 28.0));
+        assert!(y.is_none());
     }
 }


### PR DESCRIPTION
Closes #72.

Adds a "snap-align" affordance: while dragging a node (or a multi-node selection), if a side or center comes within a threshold of another node's side/center, the drag snaps along that axis so they line up - like the smart guides in design tools.

## Behaviour

- **Per-axis independent** - x and y are decided separately.
- **Coexists with snap-to-point/grid** - alignment takes priority per axis; an axis that finds no alignment falls back to the existing `snap` setting.
- **Hold to disable** - a configurable modifier (default `Alt`) temporarily suppresses alignment during a drag (the axis then falls back to snap).
- **Group-aware** - a multi-node selection aligns by its bounding box and moves rigidly, preserving its relative layout.
- **Subtle guide lines** - when an edge/center aligns, a faint line is drawn along the shared edge spanning both nodes. Optional and configurable.

## API (`Graph` builders)

- `align(bool)` - enable snap-align (default `true`).
- `align_targets(AlignTargets { edges, centers })` - which features align (default: edges only).
- `align_threshold(f32)` - snap distance in screen pixels (default derives from the style's `interact_radius`, ~5px; converted to graph units via the live zoom).
- `align_disable_modifier(egui::Modifiers)` - held to disable (default `Alt`).
- `align_guides(bool)` - draw guide lines (default `true`).
- `align_guide_stroke(egui::Stroke)` - guide stroke; width in screen pixels (default: a subtle selection-colour stroke).

## Demo

`examples/demo.rs` gains an "ALIGN CONFIG" section (enable, edges/centers, threshold, guides) to try it out.

## Notes

- The pure `align_adjust` helper is unit-tested (edges, centers, group bbox, thresholds, tie-breaks, guide geometry).
- Follow-up: socket-to-socket alignment - `AlignTargets` is shaped to add a `sockets` field.