### PR TITLE
fix: complete edge when released over a node frame

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,13 @@ pub struct GraphTempMemory {
     ///
     /// Always `Some` while the pointer is over the graph area, `None` otherwise.
     closest_socket: Option<socket::Socket>,
+    /// Whether the pointer was over any node frame during the previous frame.
+    ///
+    /// Node frames are sublayers that win egui's hit-test over the scene, so the
+    /// scene response reports "not hovered" while the pointer is over a node.
+    /// This lets socket detection still treat node frames as part of the graph
+    /// (e.g. releasing an edge over a socket that straddles a frame edge).
+    ptr_over_node: bool,
     /// The most recently observed available viewport size.
     ///
     /// Used to preserve the zoom level across viewport resizes; see
@@ -640,6 +647,12 @@ impl Graph {
             // Reset the selection dirty flag for this frame.
             gmem.selection.changed = false;
 
+            // Take the previous frame's "pointer over a node frame" flag (it is
+            // re-accumulated from each node's `contains_pointer()` as the nodes
+            // draw) so socket detection can treat node frames as part of the
+            // graph - see the `closest_socket` gate below.
+            let ptr_over_node_prev = std::mem::take(&mut gmem.ptr_over_node);
+
             // FIXME: Here we grab the global pointer and transform its position
             // to the graph scene space in order to check for initialising node
             // drag events. However, doing this means we run the risk of
@@ -655,10 +668,17 @@ impl Graph {
                     .unwrap_or_default()
                     .mul_pos(ptr_global);
 
-                // Check for the closest socket.
-                closest_socket = ui.response().hover_pos().and_then(|pos| {
-                    find_closest_socket(pos, layout, &gmem, ui).map(|(socket, _dist_sqrd)| socket)
-                });
+                // Check for the closest socket. Use the raw graph-space pointer
+                // (the scene's `hover_pos()` is `None` over a node frame) gated on
+                // the pointer being over the scene background *or* a node frame, so
+                // sockets straddling a frame edge are detectable from either side.
+                let ptr_over_graph = ptr_on_graph || ptr_over_node_prev;
+                closest_socket = if ptr_over_graph {
+                    find_closest_socket(ptr_graph, layout, &gmem, ui)
+                        .map(|(socket, _dist_sqrd)| socket)
+                } else {
+                    None
+                };
 
                 // When immutable, suppress socket presses (map to Select).
                 let closest_socket_for_interaction =

--- a/src/node.rs
+++ b/src/node.rs
@@ -405,6 +405,12 @@ impl Node {
             };
             gmem.node_sizes.insert(self.id, size);
 
+            // Treat the pointer being over this node's frame as "over the graph"
+            // for next frame's socket detection (see `lib.rs`). `contains_pointer`
+            // stays true mid-drag (drag-and-drop target semantics) and is false
+            // when a window fully occludes the frame.
+            gmem.ptr_over_node |= response.contains_pointer();
+
             let ctrl_down = ui.input(|i| i.modifiers.ctrl);
 
             // If the window is pressed, select the node.


### PR DESCRIPTION
Releasing a dragged edge over the target socket cancelled instead of connecting whenever the pointer was over the target's node frame, forcing the release onto the thin socket sliver exposed below the frame.

`closest_socket` was derived from the scene's `hover_pos()`, which is `None` while the pointer is over a node frame (frames are sublayers that win egui's hit-test over the scene). It now uses the raw graph-space pointer, gated on the pointer being over the scene background or a node frame, so sockets straddling a frame edge are detectable from either side.

Node-frame coverage is sourced from each frame's `contains_pointer()` (occlusion-aware and stable mid-drag), accumulated into a new `GraphTempMemory::ptr_over_node` flag during node drawing and consumed on the next frame. The narrow `ptr_on_graph` gate for `graph_interaction` is left untouched so a frame press still drags the node rather than starting a selection rectangle.

Closes nannou-org/egui_graph#57